### PR TITLE
Adds pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+## Any follow ups?
+
+Insert a reference to a pull request that should be reviewed before this is reviewed
+
+## Description
+Insert here a brief description of your PR, meaning, what it is adding to the project.
+If you altered something UI related, please add one or more prints to help identifying it alongside the description.
+
+*Example:*
+This PR adds nullsafety to the project
+
+## Why?
+Describe here the motive why you are proposing this change. 
+
+*Example:*
+The bigger the language jump bigger the work to update it.
+And if more code is created with the old version, the update would take even more work.
+
+## How?
+Give a brief description about your solution. 
+There is no need to explain file per file, but a generic overview would be good for future programmers looking at this.
+
+*Example:*
+1. Bumped dart version
+2. Added missing unwrappers
+
+## Testing Plan 
+What do we do for test the solution of the issue.
+
+*Example:*
+Run project unit tests


### PR DESCRIPTION
## Any follow ups?

Insert a reference to a pull request that should be reviewed before this is reviewed

## Description
Adds a pull request template that should be loaded when creating a PR

## Why?

1. Create a pattern on what's needed to open a PR
2. It's easier to fill a template then to think what to write every time
3. Ease reviews

## How?

Created a file with a template

## Testing Plan 
Not applicable