### PR TITLE
Fix CI-CD temporarily without code-climate

### DIFF
--- a/.github/workflows/reuseable_workflow.yml
+++ b/.github/workflows/reuseable_workflow.yml
@@ -18,15 +18,15 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3.1.0
+      - name: Check out code (LFS)
+        uses: nschloe/action-cached-lfs-checkout@v1.1.2
 
       # Get latest stable version of dart-lang
       - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
 
       - name: Install dependencies
         run: dart pub get
-        
+
       # Uncomment this step to verify the use of 'dart format' on each commit.
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
@@ -39,13 +39,13 @@ jobs:
       # package:test for this step to succeed. Note that Flutter projects will
       # want to change this to 'flutter test'.
       - name: Run tests
-        run: dart test
+        run: dart run test --coverage=./coverage
 
       - name: Activate coverage
         run: dart pub global activate coverage
 
-      - name: Run Code Coverage
-        run: dart pub global run coverage:test_with_coverage
+      - name: Create coverage
+        run: dart pub global run coverage:format_coverage --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
 
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v3
@@ -53,16 +53,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ${{ inputs.codecov-flag }}
           verbose: true]
-
-      - name: Codeclimate
-        uses: actions/setup-node@master
-        with:
-          node-version: '12'
-      - run: npm install -g yarn
-      - run: yarn install
-      - run: yarn build
-      - uses: paambaati/codeclimate-action@v3.0.0
-        env:
-          CC_TEST_REPORTER_ID: 945dfb58a832d233a3caeb84e3e6d3be212e8c7abcb48117fce63b9adcb43647
-        with:
-          coverageCommand: yarn coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - main
+      - fix/CI-CD
       - develop
       - release-v*
     types:
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - master
-      - main
+      - fix/CI-CD
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: ./.github/workflows/reuseable_workflow
+    uses: ./.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: ./.github/workflows/reuseable_workflow
+    uses: ./.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: ./.github/workflows/reuseable_workflow
+    uses: ./.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: ./.github/workflows/reuseable_workflow
+    uses: ./.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-      - fix/CI-CD
+      - main
       - develop
       - release-v*
     types:
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - master
-      - fix/CI-CD
+      - main
 
 # Declare default permissions as read only.
 permissions: read-all
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@fix/CI-CD
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@feature/polkadart_scale_codec
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@feature/polkadart_scale_codec
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@feature/polkadart_scale_codec
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@feature/polkadart_scale_codec
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
+    uses: reuseable_workflow.yml
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
+    uses: reuseable_workflow.yml
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
+    uses: reuseable_workflow.yml
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
+    uses: reuseable_workflow.yml
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: reuseable_workflow.yml
+    uses: ./.github/workflows/reuseable_workflow
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: reuseable_workflow.yml
+    uses: ./.github/workflows/reuseable_workflow
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: reuseable_workflow.yml
+    uses: ./.github/workflows/reuseable_workflow
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: reuseable_workflow.yml
+    uses: ./.github/workflows/reuseable_workflow
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
   ss58_codec:
     name: Test ss58_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "ss58_codec"
       working-directory: "./packages/ss58_codec"
@@ -54,7 +54,7 @@ jobs:
   ss58:
     name: Test ss58
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "ss58"
       working-directory: "./packages/ss58"
@@ -62,7 +62,7 @@ jobs:
   polkadart_scale_codec:
     name: Test polkadart_scale_codec
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "polkadart_scale_codec"
       working-directory: "./packages/polkadart_scale_codec"
@@ -70,7 +70,7 @@ jobs:
   polkadart:
     name: Test polkadart
     needs: [lints, markdown-link-check]
-    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml@main
+    uses: rankanizer/polkadart/.github/workflows/reuseable_workflow.yml
     with:
       codecov-flag: "polkadart"
       working-directory: "./polkadart"


### PR DESCRIPTION
Fix for CI-CD until Code-Climate is configured.

Optimization:
* It tests and generates the coverage file.
* This same coverage file is then uploaded to the Codecov.

Why failing Now ?
* It is tested by pointing a ref to this branch itself to use this reusable-test cases. ([f7e654d](https://github.com/rankanizer/polkadart/pull/65/commits/f7e654d0d521c6045228ebf2e50f93d925a58798))
* After successfully passing, it is again pointed back to main. 
* So it fails in this commit. ([a3b42a3](https://github.com/rankanizer/polkadart/pull/65/commits/a3b42a3fe83949d10b31ac1c5839d4526602ea07))
