### PR TITLE
create new codec type for signed 8bit integers

### DIFF
--- a/packages/polkadart_scale_codec/lib/src/core/core.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/core.dart
@@ -28,3 +28,4 @@ part '../types/codec_u32.dart';
 part '../types/codec_u64.dart';
 part '../types/codec_u128.dart';
 part '../types/codec_u256.dart';
+part '../types/codec_i8.dart';

--- a/packages/polkadart_scale_codec/lib/src/types/codec_i8.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_i8.dart
@@ -1,0 +1,30 @@
+part of '../core/core.dart';
+
+/// [ScaleCodecType] class to encode `signed 8-bit` integers.
+///
+/// Basic integers are encoded using a fixed-width little-endian (LE) format.
+///
+/// Example:
+/// ```
+/// final encoded = CodecI8.encode(69);
+/// final decoded = CodecI8.decode("0x45");
+/// ```
+///
+/// See also: https://docs.substrate.io/reference/scale-codec/
+class CodecI8 implements ScaleCodecType<int> {
+  @override
+  String encodeToHex(value) {
+    var sink = HexEncoder();
+    sink.i8(value);
+    return sink.toHex();
+  }
+
+  @override
+  int decodeFromHex(String encodedData) {
+    Source source = Source(encodedData);
+    final result = source.i8();
+    source.assertEOF();
+
+    return result;
+  }
+}

--- a/packages/polkadart_scale_codec/test/test_types/codec_i8_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_i8_test.dart
@@ -1,0 +1,110 @@
+import 'package:polkadart_scale_codec/polkadart_scale_codec.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('encode signed 8-bit to hex', () {
+    test(
+        'Given a positive integer when it is within range it should be encoded',
+        () {
+      const value = 69;
+      const expectedResult = '0x45';
+
+      expect(CodecI8().encodeToHex(value), expectedResult);
+    });
+
+    test('Should return correct encoded data when value is zero', () {
+      const value = 0;
+      const expectedResult = '0x00';
+
+      expect(CodecI8().encodeToHex(value), expectedResult);
+    });
+
+    test(
+        'Should return correct encoded data when value fits 8 bits and is negative',
+        () {
+      const smallestSupportedValue = -128;
+      const expectedResult = '0x80';
+
+      expect(CodecI8().encodeToHex(smallestSupportedValue), expectedResult);
+    });
+
+    test(
+        'Should return correct encoded data when value fits 8 bits and is positive',
+        () {
+      const largestSupportedValue = 127;
+      const expectedResult = '0x7f';
+
+      expect(CodecI8().encodeToHex(largestSupportedValue), expectedResult);
+    });
+
+    test(
+        "Given an 8 bit decoder when value is negative and can't be represented it should throw",
+        () {
+      const value = -129;
+
+      expect(
+        () => CodecI8().encodeToHex(value),
+        throwsA(isA<InvalidSizeException>()),
+      );
+    });
+
+    test(
+        "Given an 8 bit decoder when value is positive and can't be represented it should throw",
+        () {
+      const value = 128;
+
+      expect(
+        () => CodecI8().encodeToHex(value),
+        throwsA(isA<InvalidSizeException>()),
+      );
+    });
+  });
+
+  group('decode signed 8-bit integers', () {
+    test(
+        'Given an encoded string when it represents a positive integer it should be decoded',
+        () {
+      const value = '0x45';
+      const expectedResult = 69;
+
+      expect(CodecI8().decodeFromHex(value), expectedResult);
+    });
+
+    test('Given an encoded string when it represents zero it should be decoded',
+        () {
+      const value = '0x00';
+      const expectedResult = 0;
+
+      expect(CodecI8().decodeFromHex(value), expectedResult);
+    });
+
+    test(
+        'Given an encoded string when it represents the smallest supported value it should be decoded',
+        () {
+      const smallestSupportedValue = '0x80';
+      const expectedResult = -128;
+
+      expect(CodecI8().decodeFromHex(smallestSupportedValue), expectedResult);
+    });
+
+    test(
+        'Given an encoded string when it represents the biggest supported value it should be decoded',
+        () {
+      const biggestSupportedValue = '0x7f';
+      const expectedResult = 127;
+
+      expect(CodecI8().decodeFromHex(biggestSupportedValue), expectedResult);
+    });
+
+    test(
+        "Given an encoded string when it represents a integer that don't fit 8 bits it should throw",
+        () {
+      const value = '0xff7f';
+
+      expect(
+        () => CodecI8().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Any follow ups?

Please review #94 before this one.

## Description
This PR adds a new codec type for encode/decode signed 8bit integers.

## Why?
Refactoring `codec`.


## How?
1. Create new CodecI8 class.
2. Create its tests for encoding/decoding values

## Testing Plan 
Run `dart test` on polkadart_scale_codec package folder

