### PR TITLE
Fix CodecU8

### DIFF
--- a/packages/polkadart_scale_codec/lib/src/types/codec_u8.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u8.dart
@@ -4,14 +4,15 @@ part of '../core/core.dart';
 ///
 /// Basic integers are encoded using a fixed-width little-endian (LE) format.
 ///
-/// Example:
-/// ```
-/// final encoded = CodecU8.encode(69);
-/// final decoded = CodecU8.decode("0x45");
-/// ```
-///
 /// See also: https://docs.substrate.io/reference/scale-codec/
 class CodecU8 implements ScaleCodecType<int> {
+  /// Returns an encoded hex-decimal `string` from `int` [value]
+  /// using [HexEncoder] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final encoded = CodecU8.encodeToHex(69); //"0x45"
+  /// ```
   @override
   String encodeToHex(value) {
     var sink = HexEncoder();
@@ -19,9 +20,20 @@ class CodecU8 implements ScaleCodecType<int> {
     return sink.toHex();
   }
 
+  /// Returns an `int` value which represents
+  /// the [encodedData] hex-decimal `string`
+  /// using [Source] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final decoded = CodecU8.decodeFromHex("0x45"); //69
+  /// ```
   @override
   int decodeFromHex(String encodedData) {
     Source source = Source(encodedData);
-    return source.u8();
+    final result = source.u8();
+    source.assertEOF();
+
+    return result;
   }
 }

--- a/packages/polkadart_scale_codec/test/test_types/codec_i128_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_i128_test.dart
@@ -84,7 +84,7 @@ void main() {
     });
 
     test(
-        "Given an encoded string when it represents a integer that don't fit 64 bits it should throw",
+        "Given an encoded string when it represents a integer that don't fit 128 bits it should throw",
         () {
       const value =
           '0xffffff0000000000000000000000000000000000000000000000000000000000';

--- a/packages/polkadart_scale_codec/test/test_types/codec_u8_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u8_test.dart
@@ -19,15 +19,16 @@ void main() {
       expect(CodecU8().encodeToHex(value), expectedResult);
     });
 
-    test('Should return correct encoded data when value is 255', () {
-      const value = 255;
+    test(
+        'Should return correct encoded data when value fits 8 bits and is positive',
+        () {
+      const largestSupportedValue = 255;
       const expectedResult = '0xff';
 
-      expect(CodecU8().encodeToHex(value), expectedResult);
+      expect(CodecU8().encodeToHex(largestSupportedValue), expectedResult);
     });
 
-    test('Should throw InvalidSizeException when value is smaller than zero',
-        () {
+    test('Should throw InvalidSizeException when value is negative', () {
       const value = -1;
 
       expect(
@@ -36,13 +37,44 @@ void main() {
       );
     });
 
-    test('Should throw InvalidSizeException when value is greater than 256',
+    test(
+        "Given an 8 bit decoder when value is negative and can't be represented it should throw",
         () {
       const value = 256;
 
       expect(
         () => CodecU8().encodeToHex(value),
         throwsA(isA<InvalidSizeException>()),
+      );
+    });
+  });
+
+  group('decode unsigned 8-bit integers', () {
+    test('Given an encoded string when it represents zero it should be decoded',
+        () {
+      const value = '0x00';
+      const expectedResult = 0;
+
+      expect(CodecU8().decodeFromHex(value), expectedResult);
+    });
+
+    test(
+        'Given an encoded string when it represents the biggest supported value it should be decoded',
+        () {
+      const biggestSupportedValue = '0xff';
+      const expectedResult = 255;
+
+      expect(CodecU8().decodeFromHex(biggestSupportedValue), expectedResult);
+    });
+
+    test(
+        "Given an encoded string when it represents a integer that don't fit 8 bits it should throw",
+        () {
+      const value = '0xff7f';
+
+      expect(
+        () => CodecU8().decodeFromHex(value),
+        throwsA(isA<Exception>()),
       );
     });
   });


### PR DESCRIPTION
## Any follow ups?

Please review https://github.com/rankanizer/polkadart/pull/103 before this one.

## Description
This PR fix CodecU8 methods and create its decode from hex tests

## Why?
Refactoring `Codec`. 

## How?
1. Fix CodecU8 class
2. Create new CodecU8.decodeFromHex tests

## Testing Plan 
Run `dart test` in polkadart_scale_codec package folder
