### PR TITLE
Scale_codec fixes to support substrate_metadata

### DIFF
--- a/packages/polkadart_scale_codec/lib/src/core/type_exp.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/type_exp.dart
@@ -7,6 +7,10 @@ abstract class RegistryType extends Equatable {
 
   @override
   String toString() {
+    return getFormattedString();
+  }
+
+  String getFormattedString() {
     switch (kind) {
       case 'array':
         var type = (this as RegistryArrayType);
@@ -39,8 +43,9 @@ class RegistryNamedType extends RegistryType with EquatableMixin {
   @override
   List<Object?> get props => [name, params, 'named'];
 
+  // We can't call super.toString() because it will end up calling toString() defined in the Equatable class.
   @override
-  String toString() => super.toString();
+  String toString() => super.getFormattedString();
 }
 
 class RegistryArrayType extends RegistryType with EquatableMixin {
@@ -52,8 +57,9 @@ class RegistryArrayType extends RegistryType with EquatableMixin {
   @override
   List<Object?> get props => [item, length, 'array'];
 
+  // We can't call super.toString() because it will end up calling toString() defined in the Equatable class.
   @override
-  String toString() => super.toString();
+  String toString() => super.getFormattedString();
 }
 
 class RegistryTupleType extends RegistryType with EquatableMixin {
@@ -63,8 +69,9 @@ class RegistryTupleType extends RegistryType with EquatableMixin {
   @override
   List<Object?> get props => [params, 'tuple'];
 
+  // We can't call super.toString() because it will end up calling toString() defined in the Equatable class.
   @override
-  String toString() => super.toString();
+  String toString() => super.getFormattedString();
 }
 
 class TypeExpParser {


### PR DESCRIPTION
## Description
Fixes to allow proper functioning and exposed functions for substrate_metadata.

## Why?
As recently a PR of `Gabriel`  was merged to main which hindered the functioning of substrate_metadata and conflicted the arguments in certain functions.

This PR helps to fix those issues.

## How?
* Corrected the working of Variant with removal of `__kind` and `value` keys.
* Will help in writing test cases for `enum`.
* Replaced `HexEncoder` with `ScaleCodecEncoder` in function arguments.

## Testing Plan 
* All tests passes for `polkadart_scale_codec` without effecting anything.
* All chain tests passes in `feature/substrate_metadata`.