### PR TITLE
Fix CodecU32 and create tests

### DIFF
--- a/packages/polkadart_scale_codec/README.md
+++ b/packages/polkadart_scale_codec/README.md
@@ -37,23 +37,24 @@ Now in your `Dart` code, you can use:
 import 'package:polkadart_scale_codec/polkadart_scale_codec.dart';
 ```
 
-### Supported types: 
-Types | Sign
---- | ---
-Unsigned Int | `u8, u16, u32, u64, u128, u256`
-Signed Int | `i8, i16, i32, i64, i128, i256`
-String | `Text`
-Boolean | `bool`
-Address | `Address`
-Bytes | `Bytes`
-Compact | `Compact<T>`
-Enum | `_enum`
-Struct | `_struct`
-FixedVec | `[u8, length]`
-BitVec | `BitVec`
-Option | `Option<T>`
-Tuple | `(K, V, T....)`
-Result | `Result<Ok, Err>`
+### Supported types:
+
+| Types        | Sign                            |
+| ------------ | ------------------------------- |
+| Unsigned Int | `u8, u16, u32, u64, u128, u256` |
+| Signed Int   | `i8, i16, i32, i64, i128, i256` |
+| String       | `Text`                          |
+| Boolean      | `bool`                          |
+| Address      | `Address`                       |
+| Bytes        | `Bytes`                         |
+| Compact      | `Compact<T>`                    |
+| Enum         | `_enum`                         |
+| Struct       | `_struct`                       |
+| FixedVec     | `[u8, length]`                  |
+| BitVec       | `BitVec`                        |
+| Option       | `Option<T>`                     |
+| Tuple        | `(K, V, T....)`                 |
+| Result       | `Result<Ok, Err>`               |
 
 # Usage
 

--- a/packages/polkadart_scale_codec/lib/src/core/source.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/source.dart
@@ -168,7 +168,7 @@ class Source {
 
   void assertEOF() {
     if (hasBytes()) {
-      throw Exception('Unprocessed data left');
+      throw UnprocessedDataLeftException();
     }
   }
 }

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u32.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u32.dart
@@ -11,7 +11,7 @@ class CodecU32 implements ScaleCodecType<int> {
   ///
   /// Example:
   /// ```
-  /// final encoded = CodecU32.encodeToHex(16777215); // "0xffffff00"
+  /// final encoded = CodecU32().encodeToHex(16777215); // "0xffffff00"
   /// ```
   @override
   String encodeToHex(value) {
@@ -25,7 +25,7 @@ class CodecU32 implements ScaleCodecType<int> {
   ///
   /// Example:
   /// ```
-  /// final decoded = CodecU32.decodeFromHex("0xffffff00"); // 16777215
+  /// final decoded = CodecU32().decodeFromHex("0xffffff00"); // 16777215
   /// ```
   @override
   int decodeFromHex(String encodedData) {

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u32.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u32.dart
@@ -4,14 +4,15 @@ part of '../core/core.dart';
 ///
 /// Basic integers are encoded using a fixed-width little-endian (LE) format.
 ///
-/// Example:
-/// ```
-/// final encoded = CodecU32.encode(16777215);
-/// final decoded = CodecU32.decode("0xffffff00");
-/// ```
-///
 /// See also: https://docs.substrate.io/reference/scale-codec/
 class CodecU32 implements ScaleCodecType<int> {
+  /// Returns an encoded hex-decimal `string` from `int` [value]
+  /// using [HexEncoder] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final encoded = CodecU32.encodeToHex(16777215); // "0xffffff00"
+  /// ```
   @override
   String encodeToHex(value) {
     var sink = HexEncoder();
@@ -19,9 +20,19 @@ class CodecU32 implements ScaleCodecType<int> {
     return sink.toHex();
   }
 
+  /// Returns an `int` value which the hex-decimal `string`
+  /// [encodedData] represents, using [Source] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final decoded = CodecU32.decodeFromHex("0xffffff00"); // 16777215
+  /// ```
   @override
   int decodeFromHex(String encodedData) {
     Source source = Source(encodedData);
-    return source.u32();
+    final result = source.u32();
+    source.assertEOF();
+
+    return result;
   }
 }

--- a/packages/polkadart_scale_codec/lib/src/util/exceptions.dart
+++ b/packages/polkadart_scale_codec/lib/src/util/exceptions.dart
@@ -93,3 +93,18 @@ class UnexpectedTypeException implements Exception {
   @override
   String toString() => 'Expecting `$expectedType`, but found `$receivedType`';
 }
+
+/// Exception thrown in [Source] `assertEOF` when decoded bytes data
+/// is larger and don't fit in its type.
+///
+/// Example:
+/// ```
+/// final value = "0xffffff";
+/// final decoded = CodecU16().decodeFromHex(value); // will throw!
+/// ```
+class UnprocessedDataLeftException implements Exception {
+  const UnprocessedDataLeftException();
+
+  @override
+  String toString() => 'Unprocessed data left';
+}

--- a/packages/polkadart_scale_codec/test/test_types/codec_u16_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u16_test.dart
@@ -74,7 +74,7 @@ void main() {
 
       expect(
         () => CodecU16().decodeFromHex(value),
-        throwsA(isA<Exception>()),
+        throwsA(isA<UnprocessedDataLeftException>()),
       );
     });
 

--- a/packages/polkadart_scale_codec/test/test_types/codec_u32_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u32_test.dart
@@ -48,4 +48,34 @@ void main() {
       );
     });
   });
+
+  group('decode unsigned 32-bit integers', () {
+    test('Given an encoded string when it represents zero it should be decoded',
+        () {
+      const value = '0x00000000';
+      const expectedResult = 0;
+
+      expect(CodecU32().decodeFromHex(value), expectedResult);
+    });
+
+    test(
+        'Given an encoded string when it represents the largest supported value it should be decoded',
+        () {
+      const largestSupportedValue = '0xffffffff';
+      const expectedResult = 4294967295;
+
+      expect(CodecU32().decodeFromHex(largestSupportedValue), expectedResult);
+    });
+
+    test(
+        "Given an encoded string when it represents a integer that don't fit 32 bits it should throw",
+        () {
+      const value = '0xffff';
+
+      expect(
+        () => CodecU32().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
 }

--- a/packages/polkadart_scale_codec/test/test_types/codec_u32_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u32_test.dart
@@ -74,7 +74,7 @@ void main() {
 
       expect(
         () => CodecU32().decodeFromHex(value),
-        throwsA(isA<Exception>()),
+        throwsA(isA<UnprocessedDataLeftException>()),
       );
     });
 

--- a/packages/polkadart_scale_codec/test/test_types/codec_u32_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u32_test.dart
@@ -68,13 +68,24 @@ void main() {
     });
 
     test(
-        "Given an encoded string when it represents a integer that don't fit 32 bits it should throw",
+        "Given an encoded string when it represents a integer larger than 32 bits it should throw",
+        () {
+      const value = '0xffffffffffff';
+
+      expect(
+        () => CodecU32().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test(
+        "Given an encoded string when it represents a integer smaller than 32 bits it should throw",
         () {
       const value = '0xffff';
 
       expect(
         () => CodecU32().decodeFromHex(value),
-        throwsA(isA<Exception>()),
+        throwsA(isA<EOFException>()),
       );
     });
   });


### PR DESCRIPTION
## Description
This PR fix CodecU32 methods and create its decode from hex tests

## Why?
Refactoring `Codec`. 

## How?
1. Fix CodecU32 class
2. Create new CodecU32.decodeFromHex tests

## Testing Plan 
Run `dart test` in polkadart_scale_codec package folder
