### PR TITLE
Fix CodecU64 documentation and create tests

### DIFF
--- a/packages/polkadart_scale_codec/README.md
+++ b/packages/polkadart_scale_codec/README.md
@@ -37,23 +37,24 @@ Now in your `Dart` code, you can use:
 import 'package:polkadart_scale_codec/polkadart_scale_codec.dart';
 ```
 
-### Supported types: 
-Types | Sign
---- | ---
-Unsigned Int | `u8, u16, u32, u64, u128, u256`
-Signed Int | `i8, i16, i32, i64, i128, i256`
-String | `Text`
-Boolean | `bool`
-Address | `Address`
-Bytes | `Bytes`
-Compact | `Compact<T>`
-Enum | `_enum`
-Struct | `_struct`
-FixedVec | `[u8, length]`
-BitVec | `BitVec`
-Option | `Option<T>`
-Tuple | `(K, V, T....)`
-Result | `Result<Ok, Err>`
+### Supported types:
+
+| Types        | Sign                            |
+| ------------ | ------------------------------- |
+| Unsigned Int | `u8, u16, u32, u64, u128, u256` |
+| Signed Int   | `i8, i16, i32, i64, i128, i256` |
+| String       | `Text`                          |
+| Boolean      | `bool`                          |
+| Address      | `Address`                       |
+| Bytes        | `Bytes`                         |
+| Compact      | `Compact<T>`                    |
+| Enum         | `_enum`                         |
+| Struct       | `_struct`                       |
+| FixedVec     | `[u8, length]`                  |
+| BitVec       | `BitVec`                        |
+| Option       | `Option<T>`                     |
+| Tuple        | `(K, V, T....)`                 |
+| Result       | `Result<Ok, Err>`               |
 
 # Usage
 

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u64.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u64.dart
@@ -4,14 +4,15 @@ part of '../core/core.dart';
 ///
 /// Basic integers are encoded using a fixed-width little-endian (LE) format.
 ///
-/// Example:
-/// ```
-/// final encoded = CodecU64.encode(16777215);
-/// final decoded = CodecU64.decode("0xffffff00");
-/// ```
-///
 /// See also: https://docs.substrate.io/reference/scale-codec/
 class CodecU64 implements ScaleCodecType<BigInt> {
+  /// Returns an encoded hex-decimal `string` from `BigInt` [value]
+  /// using [HexEncoder] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final encoded = CodecI64.encodeToHex(9223372036854775807.toBigInt); // "0xffffffffffffff7f"
+  /// ```
   @override
   String encodeToHex(value) {
     var sink = HexEncoder();
@@ -19,9 +20,19 @@ class CodecU64 implements ScaleCodecType<BigInt> {
     return sink.toHex();
   }
 
+  /// Returns an `BigInt` value which the hex-decimal `string`
+  /// [encodedData] represents, using [Source] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final decoded = CodecI64.decodeFromHex("0xffffffffffffff7f"); // 9223372036854775807
+  /// ```
   @override
   BigInt decodeFromHex(String encodedData) {
     Source source = Source(encodedData);
-    return source.u64();
+    final result = source.u64();
+    source.assertEOF();
+
+    return result;
   }
 }

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u64.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u64.dart
@@ -11,7 +11,7 @@ class CodecU64 implements ScaleCodecType<BigInt> {
   ///
   /// Example:
   /// ```
-  /// final encoded = CodecI64.encodeToHex(9223372036854775807.toBigInt); // "0xffffffffffffff7f"
+  /// final encoded = CodecU64.encodeToHex(9223372036854775807.toBigInt); // "0xffffffffffffff7f"
   /// ```
   @override
   String encodeToHex(value) {
@@ -25,7 +25,7 @@ class CodecU64 implements ScaleCodecType<BigInt> {
   ///
   /// Example:
   /// ```
-  /// final decoded = CodecI64.decodeFromHex("0xffffffffffffff7f"); // 9223372036854775807
+  /// final decoded = CodecU64.decodeFromHex("0xffffffffffffff7f"); // 9223372036854775807
   /// ```
   @override
   BigInt decodeFromHex(String encodedData) {

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u64.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u64.dart
@@ -11,7 +11,7 @@ class CodecU64 implements ScaleCodecType<BigInt> {
   ///
   /// Example:
   /// ```
-  /// final encoded = CodecU64.encodeToHex(9223372036854775807.toBigInt); // "0xffffffffffffff7f"
+  /// final encoded = CodecU64().encodeToHex(9223372036854775807.toBigInt); // "0xffffffffffffff7f"
   /// ```
   @override
   String encodeToHex(value) {
@@ -25,7 +25,7 @@ class CodecU64 implements ScaleCodecType<BigInt> {
   ///
   /// Example:
   /// ```
-  /// final decoded = CodecU64.decodeFromHex("0xffffffffffffff7f"); // 9223372036854775807
+  /// final decoded = CodecU64().decodeFromHex("0xffffffffffffff7f"); // 9223372036854775807
   /// ```
   @override
   BigInt decodeFromHex(String encodedData) {

--- a/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
@@ -53,7 +53,7 @@ void main() {
     test('Given an encoded string when it represents zero it should be decoded',
         () {
       const value = '0x0000000000000000';
-      const expectedResult = 0;
+      final expectedResult = 0.toBigInt;
 
       expect(CodecU64().decodeFromHex(value), expectedResult);
     });

--- a/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
@@ -48,4 +48,34 @@ void main() {
       );
     });
   });
+
+  group('decode unsigned 64-bit integers', () {
+    test('Given an encoded string when it represents zero it should be decoded',
+        () {
+      const value = '0x0000000000000000';
+      const expectedResult = 0;
+
+      expect(CodecU64().decodeFromHex(value), expectedResult);
+    });
+
+    test(
+        'Given an encoded string when it represents the largest supported value it should be decoded',
+        () {
+      const largestSupportedValue = '0xffffffffffffffff';
+      final expectedResult = '18446744073709551615'.toBigInt;
+
+      expect(CodecU64().decodeFromHex(largestSupportedValue), expectedResult);
+    });
+
+    test(
+        "Given an encoded string when it represents a integer that don't fit 64 bits it should throw",
+        () {
+      const value = '0xffff';
+
+      expect(
+        () => CodecU64().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
 }

--- a/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
@@ -13,7 +13,7 @@ void main() {
     });
 
     test('Should return correct encoded data when value is zero', () {
-      final value = BigInt.from(0);
+      final value = BigInt.zero;
       const expectedResult = '0x0000000000000000';
 
       expect(CodecU64().encodeToHex(value), expectedResult);
@@ -22,14 +22,14 @@ void main() {
     test(
         'Should return correct encoded data when value fits 64 bits and is positive',
         () {
-      final largestSupportedValue = BigInt.parse('18446744073709551615');
+      final largestSupportedValue = '18446744073709551615'.toBigInt;
       const expectedResult = '0xffffffffffffffff';
 
       expect(CodecU64().encodeToHex(largestSupportedValue), expectedResult);
     });
 
     test('Should throw InvalidSizeException when value is negative', () {
-      final value = BigInt.from(-1);
+      final value = (-1).toBigInt;
 
       expect(
         () => CodecU64().encodeToHex(value),
@@ -40,7 +40,7 @@ void main() {
     test(
         "Given an 64 bit decoder when value is positive and can't be represented it should throw",
         () {
-      final value = BigInt.parse('18446744073709551616');
+      final value = '18446744073709551616'.toBigInt;
 
       expect(
         () => CodecU64().encodeToHex(value),
@@ -53,7 +53,7 @@ void main() {
     test('Given an encoded string when it represents zero it should be decoded',
         () {
       const value = '0x0000000000000000';
-      final expectedResult = 0.toBigInt;
+      final expectedResult = BigInt.zero;
 
       expect(CodecU64().decodeFromHex(value), expectedResult);
     });
@@ -74,7 +74,7 @@ void main() {
 
       expect(
         () => CodecU64().decodeFromHex(value),
-        throwsA(isA<Exception>()),
+        throwsA(isA<UnprocessedDataLeftException>()),
       );
     });
 

--- a/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u64_test.dart
@@ -68,13 +68,24 @@ void main() {
     });
 
     test(
-        "Given an encoded string when it represents a integer that don't fit 64 bits it should throw",
+        "Given an encoded string when it represents a integer larger than 64 bits it should throw",
+        () {
+      const value = '0xffffffffffffffffffffffffffffffff';
+
+      expect(
+        () => CodecU64().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test(
+        "Given an encoded string when it represents a integer smaller than 64 bits it should throw",
         () {
       const value = '0xffff';
 
       expect(
         () => CodecU64().decodeFromHex(value),
-        throwsA(isA<Exception>()),
+        throwsA(isA<EOFException>()),
       );
     });
   });


### PR DESCRIPTION

## Description
This PR fix CodecU64 decode method and create its tests

## Why?
Refactoring `Codec`. 

## How?
1. Fix CodecU64 class
2. Create new CodecU64.decodeFromHex tests

## Testing Plan 
Run `dart test` in polkadart_scale_codec package folder
