### PR TITLE
Create CodecU128 decode tests

### DIFF
--- a/packages/polkadart_scale_codec/README.md
+++ b/packages/polkadart_scale_codec/README.md
@@ -37,23 +37,24 @@ Now in your `Dart` code, you can use:
 import 'package:polkadart_scale_codec/polkadart_scale_codec.dart';
 ```
 
-### Supported types: 
-Types | Sign
---- | ---
-Unsigned Int | `u8, u16, u32, u64, u128, u256`
-Signed Int | `i8, i16, i32, i64, i128, i256`
-String | `Text`
-Boolean | `bool`
-Address | `Address`
-Bytes | `Bytes`
-Compact | `Compact<T>`
-Enum | `_enum`
-Struct | `_struct`
-FixedVec | `[u8, length]`
-BitVec | `BitVec`
-Option | `Option<T>`
-Tuple | `(K, V, T....)`
-Result | `Result<Ok, Err>`
+### Supported types:
+
+| Types        | Sign                            |
+| ------------ | ------------------------------- |
+| Unsigned Int | `u8, u16, u32, u64, u128, u256` |
+| Signed Int   | `i8, i16, i32, i64, i128, i256` |
+| String       | `Text`                          |
+| Boolean      | `bool`                          |
+| Address      | `Address`                       |
+| Bytes        | `Bytes`                         |
+| Compact      | `Compact<T>`                    |
+| Enum         | `_enum`                         |
+| Struct       | `_struct`                       |
+| FixedVec     | `[u8, length]`                  |
+| BitVec       | `BitVec`                        |
+| Option       | `Option<T>`                     |
+| Tuple        | `(K, V, T....)`                 |
+| Result       | `Result<Ok, Err>`               |
 
 # Usage
 

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u128.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u128.dart
@@ -11,7 +11,7 @@ class CodecU128 implements ScaleCodecType<BigInt> {
   ///
   /// Example:
   /// ```
-  /// final encoded = CodecU128.encodeToHex(16777215.toBigInt); // "0xffffff00000000000000000000000000"
+  /// final encoded = CodecU128().encodeToHex(16777215.toBigInt); // "0xffffff00000000000000000000000000"
   /// ```
   @override
   String encodeToHex(value) {
@@ -25,7 +25,7 @@ class CodecU128 implements ScaleCodecType<BigInt> {
   ///
   /// Example:
   /// ```
-  /// final decoded = CodecU128.decodeFromHex("0xffffff00000000000000000000000000"); // 16777215
+  /// final decoded = CodecU128().decodeFromHex("0xffffff00000000000000000000000000"); // 16777215
   /// ```
   @override
   BigInt decodeFromHex(String encodedData) {

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u128.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u128.dart
@@ -30,6 +30,9 @@ class CodecU128 implements ScaleCodecType<BigInt> {
   @override
   BigInt decodeFromHex(String encodedData) {
     Source source = Source(encodedData);
-    return source.u128();
+    final result = source.u128();
+    source.assertEOF();
+
+    return result;
   }
 }

--- a/packages/polkadart_scale_codec/lib/src/types/codec_u128.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_u128.dart
@@ -4,14 +4,15 @@ part of '../core/core.dart';
 ///
 /// Basic integers are encoded using a fixed-width little-endian (LE) format.
 ///
-/// Example:
-/// ```
-/// final encoded = CodecU128.encode(16777215);
-/// final decoded = CodecU128.decode("0xffffff00000000000000000000000000");
-/// ```
-///
 /// See also: https://docs.substrate.io/reference/scale-codec/
 class CodecU128 implements ScaleCodecType<BigInt> {
+  /// Returns an encoded hex-decimal `string` from `BigInt` [value]
+  /// using [HexEncoder] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final encoded = CodecU128.encodeToHex(16777215.toBigInt); // "0xffffff00000000000000000000000000"
+  /// ```
   @override
   String encodeToHex(value) {
     var sink = HexEncoder();
@@ -19,6 +20,13 @@ class CodecU128 implements ScaleCodecType<BigInt> {
     return sink.toHex();
   }
 
+  /// Returns an `BigInt` value which the hex-decimal `string`
+  /// [encodedData] represents, using [Source] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final decoded = CodecU128.decodeFromHex("0xffffff00000000000000000000000000"); // 16777215
+  /// ```
   @override
   BigInt decodeFromHex(String encodedData) {
     Source source = Source(encodedData);

--- a/packages/polkadart_scale_codec/test/test_types/codec_u128_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u128_test.dart
@@ -49,4 +49,34 @@ void main() {
       );
     });
   });
+
+  group('decode unsigned 128-bit integers', () {
+    test('Given an encoded string when it represents zero it should be decoded',
+        () {
+      const value = '0x00000000000000000000000000000000';
+      final expectedResult = 0.toBigInt;
+
+      expect(CodecU128().decodeFromHex(value), expectedResult);
+    });
+
+    test(
+        'Given an encoded string when it represents the largest supported value it should be decoded',
+        () {
+      const largestSupportedValue = '0xffffffffffffffffffffffffffffff7f';
+      final expectedResult = '170141183460469231731687303715884105727'.toBigInt;
+
+      expect(CodecU128().decodeFromHex(largestSupportedValue), expectedResult);
+    });
+
+    test(
+        "Given an encoded string when it represents a integer that don't fit 128 bits it should throw",
+        () {
+      const value = '0xffff';
+
+      expect(
+        () => CodecU128().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
 }

--- a/packages/polkadart_scale_codec/test/test_types/codec_u128_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_u128_test.dart
@@ -69,13 +69,25 @@ void main() {
     });
 
     test(
-        "Given an encoded string when it represents a integer that don't fit 128 bits it should throw",
+        "Given an encoded string when it represents a integer larger fit 128 bits it should throw",
+        () {
+      const value =
+          '0xffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffff7f';
+
+      expect(
+        () => CodecU128().decodeFromHex(value),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test(
+        "Given an encoded string when it represents a integer smaller 128 bits it should throw",
         () {
       const value = '0xffff';
 
       expect(
         () => CodecU128().decodeFromHex(value),
-        throwsA(isA<Exception>()),
+        throwsA(isA<EOFException>()),
       );
     });
   });


### PR DESCRIPTION
## Any follow up?
#125 

## Description
This PR fix CodecU128 decode method and create its tests

## Why?
Refactoring `Codec`. 

## How?
1. Fix CodecU128 class
2. Create new CodecU128.decodeFromHex tests

## Testing Plan 
Run `dart test` in polkadart_scale_codec package folder
