### PR TITLE
Create new codec type for Strings

### DIFF
--- a/packages/polkadart_scale_codec/lib/src/core/core.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/core.dart
@@ -34,3 +34,4 @@ part '../types/codec_i32.dart';
 part '../types/codec_i64.dart';
 part '../types/codec_i128.dart';
 part '../types/codec_i256.dart';
+part '../types/codec_string.dart';

--- a/packages/polkadart_scale_codec/lib/src/core/types.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/types.dart
@@ -240,17 +240,17 @@ abstract class Type {
   Type({required this.kind, this.path, this.docs});
 }
 
-/// All `Scale Codec` supported types implements [ScaleCodecType]
+/// All `Scale Codec` supported types implements [ScaleCodecType].
 ///
 /// Supported types:
-/// ```dart
-/// CodecU8();
-/// CodecU16();
-/// CodecU32();
-/// CodecU64();
-/// CodecU128();
-/// CodecU256();
-/// ```
+///
+/// Unsigned integers:
+/// [CodecU8], [CodecU16], [CodecU32], [CodecU64], [CodecU128], [CodecU256].
+///
+/// Signed integers:
+/// [CodecI8], [CodecI16], [CodecI32], [CodecI64], [CodecI128], [CodecI256].
+///
+/// Strings: [CodecString].
 ///
 /// See also: https://docs.substrate.io/reference/scale-codec/
 abstract class ScaleCodecType<T> {

--- a/packages/polkadart_scale_codec/lib/src/types/codec_string.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_string.dart
@@ -1,0 +1,38 @@
+part of '../core/core.dart';
+
+/// [ScaleCodecType] class to encode and decode `Strings`.
+///
+/// Strings are Vectors of bytes (Vec<u8>) containing a valid UTF8 sequence.
+///
+/// See also: https://docs.substrate.io/reference/scale-codec/
+class CodecString implements ScaleCodecType<String> {
+  /// Returns an encoded hex-decimal `String` from `String` [value]
+  /// using [HexEncoder] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final encoded = CodecString.encodeToHex("Test"); //"0x1054657374"
+  /// ```
+  @override
+  String encodeToHex(value) {
+    var sink = HexEncoder();
+    sink.str(value);
+    return sink.toHex();
+  }
+
+  /// Returns an `String` value which the hex-decimal `String`
+  /// [encodedData] represents, using [Source] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final decoded = CodecString.decodeFromHex("0x1054657374"); //Test
+  /// ```
+  @override
+  String decodeFromHex(String encodedData) {
+    Source source = Source(encodedData);
+    final result = source.str();
+    source.assertEOF();
+
+    return result;
+  }
+}

--- a/packages/polkadart_scale_codec/lib/src/types/codec_string.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_string.dart
@@ -11,7 +11,7 @@ class CodecString implements ScaleCodecType<String> {
   ///
   /// Example:
   /// ```
-  /// final encoded = CodecString.encodeToHex("Test"); //"0x1054657374"
+  /// final encoded = CodecString().encodeToHex("Test"); //"0x1054657374"
   /// ```
   @override
   String encodeToHex(value) {
@@ -25,7 +25,7 @@ class CodecString implements ScaleCodecType<String> {
   ///
   /// Example:
   /// ```
-  /// final decoded = CodecString.decodeFromHex("0x1054657374"); //Test
+  /// final decoded = CodecString().decodeFromHex("0x1054657374"); //Test
   /// ```
   @override
   String decodeFromHex(String encodedData) {

--- a/packages/polkadart_scale_codec/test/test_types/codec_string_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_string_test.dart
@@ -1,0 +1,21 @@
+import 'package:polkadart_scale_codec/polkadart_scale_codec.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  test('Given a custom string it should be encoded', () {
+    const value = 'Test';
+    const expectedResult = '0x1054657374';
+
+    expect(CodecString().encodeToHex(value), expectedResult);
+  });
+
+  test(
+      'Given a custom string which represents a string value it should be decoded',
+      () {
+    const value = '0x2c5363616c6520436f646563';
+    const expectedResult = 'Scale Codec';
+
+    expect(CodecString().decodeFromHex(value), expectedResult);
+  });
+}


### PR DESCRIPTION
## Description
This PR adds a new codec type for encode/decode Strings.

## Why?
Refactoring `Codec`. 

## How?
1. Create new CodecString class
2. Create its tests for encoding/decoding values

## Testing Plan 
Run `dart test` in polkadart_scale_codec package folder
