### PR TITLE
Create new codec type for encode/decode boolean

### DIFF
--- a/packages/polkadart_scale_codec/lib/src/core/core.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/core.dart
@@ -34,3 +34,4 @@ part '../types/codec_i32.dart';
 part '../types/codec_i64.dart';
 part '../types/codec_i128.dart';
 part '../types/codec_i256.dart';
+part '../types/codec_boolean.dart';

--- a/packages/polkadart_scale_codec/lib/src/core/types.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/types.dart
@@ -243,14 +243,14 @@ abstract class Type {
 /// All `Scale Codec` supported types implements [ScaleCodecType]
 ///
 /// Supported types:
-/// ```dart
-/// CodecU8();
-/// CodecU16();
-/// CodecU32();
-/// CodecU64();
-/// CodecU128();
-/// CodecU256();
-/// ```
+///
+/// Unsigned integers:
+/// [CodecU8], [CodecU16], [CodecU32], [CodecU64], [CodecU128], [CodecU256].
+///
+/// Signed integers:
+/// [CodecI8], [CodecI16], [CodecI32], [CodecI64], [CodecI128], [CodecI256].
+///
+/// Boolean: [CodecBoolean]
 ///
 /// See also: https://docs.substrate.io/reference/scale-codec/
 abstract class ScaleCodecType<T> {

--- a/packages/polkadart_scale_codec/lib/src/types/codec_boolean.dart
+++ b/packages/polkadart_scale_codec/lib/src/types/codec_boolean.dart
@@ -1,0 +1,38 @@
+part of '../core/core.dart';
+
+/// [ScaleCodecType] class to encode and decode `bool` values.
+///
+/// Boolean values are encoded using the least significant bit of a single byte.
+///
+/// See also: https://docs.substrate.io/reference/scale-codec/
+class CodecBoolean implements ScaleCodecType<bool> {
+  /// Returns an encoded hex-decimal `String` from `bool` [value]
+  /// using [HexEncoder] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final encoded = CodecBoolean().encodeToHex(false); //"0x00"
+  /// ```
+  @override
+  String encodeToHex(value) {
+    var sink = HexEncoder();
+    sink.boolean(value);
+    return sink.toHex();
+  }
+
+  /// Returns a `bool` value which represents the [encodedData] hex-decimal
+  /// `string` using [Source] methods.
+  ///
+  /// Example:
+  /// ```
+  /// final decoded = CodecBoolean().decodeFromHex("0x01"); //true
+  /// ```
+  @override
+  bool decodeFromHex(String encodedData) {
+    Source source = Source(encodedData);
+    final result = source.boolean();
+    source.assertEOF();
+
+    return result;
+  }
+}

--- a/packages/polkadart_scale_codec/test/test_types/codec_boolean_test.dart
+++ b/packages/polkadart_scale_codec/test/test_types/codec_boolean_test.dart
@@ -1,0 +1,33 @@
+import 'package:polkadart_scale_codec/src/core/core.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  test('Given true should be encoded to 0x01', () {
+    final value = true;
+    final expectedResult = '0x01';
+
+    expect(CodecBoolean().encodeToHex(value), expectedResult);
+  });
+
+  test('Given false should be encoded to 0x01', () {
+    final value = false;
+    final expectedResult = '0x00';
+
+    expect(CodecBoolean().encodeToHex(value), expectedResult);
+  });
+
+  test('Given string when it represents true it should be decoded', () {
+    final value = '0x01';
+    final expectedResult = true;
+
+    expect(CodecBoolean().decodeFromHex(value), expectedResult);
+  });
+
+  test('Given string when it represents false it should be decoded', () {
+    final value = '0x00';
+    final expectedResult = false;
+
+    expect(CodecBoolean().decodeFromHex(value), expectedResult);
+  });
+}


### PR DESCRIPTION
## Description
This PR adds a new codec type for encode/decode `Booleans`.

## Why?
Refactoring `Codec`. 

## How?
1. Create new CodecBoolean class
2. Create its tests for encoding/decoding values

## Testing Plan 
Run `dart test` in polkadart_scale_codec package folder
