### PR TITLE
Simplify super calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 ## PolkaDart
 
 This library provides a clean wrapper around all the methods exposed by a Polkadot/Substrate network client and defines all the types exposed by a node, this API provides developers the ability to query a node and interact with the Polkadot or Substrate chains using Dart.
-		
+
 All code is made available with a [permissive Apache-2.0 license](./LICENSE).
-		
+
 ## [polkadart-scale-codec](./packages/polkadart_scale_codec/)
 
 A Dart implementation of [SCALE](https://docs.substrate.io/reference/scale-codec/), Substrate uses a lightweight and efficient encoding and decoding program to optimize how data is sent and received over the network. The program used to serialize and deserialize data is called the SCALE codec, with SCALE being an acronym for simple concatenated aggregate little-endian.
@@ -16,7 +16,6 @@ A Dart implementation of [SCALE](https://docs.substrate.io/reference/scale-codec
 ## [ss58](./packages/ss58/)
 
 A Dart implementation of [SS58](https://docs.substrate.io/reference/address-formats/). The SS58 is the default Substrate address format, this encoded address format is based on the Bitcoin Base-58-check format, but with a few modifications specifically designed to suit Substrate-based chains. You can use other address formats for Substrate-based chains. However, the SS58 address format provides a base-58 encoded value that can identify a specific account on any Substrate chain. Because different chains can have different ways of identifying accounts, the SS58 address is designed to be extensible.
-		
 
 ### Basic format
 
@@ -69,27 +68,28 @@ You can run all tests from the library by running `docker compose up`.
 🟡 = Partially implemented and under active development.<br/>
 🔴 = Not supported yet but on-deck to be implemented soon.
 
-|                      | Status  |
-| -------------------- |:-------:|
-| Scale Codec Encoder  | ✅      |
-| Scale Codec Decoder  | ✅      |
-| SS58 Format          | ✅      |
-| Parse Metadata v14   | ✅      |
-| Coverage and Tests   | ✅      |
-| Substrate Metadata   | 🟡      |
-| RPC                  | 🔴      |
-| Websockets           | 🔴      |
-| Crypto               | 🔴      |
+|                     | Status |
+| ------------------- | :----: |
+| Scale Codec Encoder |   ✅    |
+| Scale Codec Decoder |   ✅    |
+| SS58 Format         |   ✅    |
+| Parse Metadata v14  |   ✅    |
+| Coverage and Tests  |   ✅    |
+| Substrate Metadata  |   🟡    |
+| RPC                 |   🔴    |
+| Websockets          |   🔴    |
+| Crypto              |   🔴    |
 
 ### Substrate Metadata
-|                         | Status  |
-| ----------------------- |:-------:|
-| Parse Metadata v14      | ✅      |
-| Parse Metadata pre-v14  | ✅      |
-| JSON-RPC                | 🔴      |
-| Constants               | 🔴      |
-| Read Storage            | 🔴      |
-| Extrinsics              | 🔴      |
-| Events                  | 🔴      |
-| Errors                  | 🔴      |
-| SmartContracts          | 🔴      |
+
+|                        | Status |
+| ---------------------- | :----: |
+| Parse Metadata v14     |   ✅    |
+| Parse Metadata pre-v14 |   ✅    |
+| JSON-RPC               |   🔴    |
+| Constants              |   🔴    |
+| Read Storage           |   🔴    |
+| Extrinsics             |   🔴    |
+| Events                 |   🔴    |
+| Errors                 |   🔴    |
+| SmartContracts         |   🔴    |

--- a/packages/polkadart_scale_codec/lib/src/core/codec_variant.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/codec_variant.dart
@@ -11,51 +11,35 @@ enum CodecVariantKind {
 ///
 /// CodecStructVariant
 class CodecStructVariant extends CodecVariant {
-  @override
-  final String name;
-  @override
-  final int index;
   final CodecStructType def;
   const CodecStructVariant(
-      {required this.name, required this.index, required this.def})
-      : super(kind: CodecVariantKind.struct, name: name, index: index);
+      {required super.name, required super.index, required this.def})
+      : super(kind: CodecVariantKind.struct);
 }
 
 ///
 /// CodecTupleVariant
 class CodecTupleVariant extends CodecVariant {
-  @override
-  final String name;
-  @override
-  final int index;
   final TupleType def;
   const CodecTupleVariant(
-      {required this.name, required this.index, required this.def})
-      : super(kind: CodecVariantKind.tuple, name: name, index: index);
+      {required super.name, required super.index, required this.def})
+      : super(kind: CodecVariantKind.tuple);
 }
 
 ///
 /// CodecValueVariant
 class CodecValueVariant extends CodecVariant {
-  @override
-  final String name;
-  @override
-  final int index;
   final int type;
   const CodecValueVariant(
-      {required this.name, required this.index, required this.type})
-      : super(kind: CodecVariantKind.value, name: name, index: index);
+      {required super.name, required super.index, required this.type})
+      : super(kind: CodecVariantKind.value);
 }
 
 ///
 /// CodecEmptyVariant
 class CodecEmptyVariant extends CodecVariant {
-  @override
-  final String name;
-  @override
-  final int index;
-  const CodecEmptyVariant({required this.name, required this.index})
-      : super(kind: CodecVariantKind.empty, name: name, index: index);
+  const CodecEmptyVariant({required super.name, required super.index})
+      : super(kind: CodecVariantKind.empty);
 }
 
 ///

--- a/packages/polkadart_scale_codec/lib/src/core/types.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/types.dart
@@ -53,7 +53,6 @@ enum Primitive {
 ///
 /// PrimitiveType
 class PrimitiveType extends Type with CodecType {
-
   /// Value from [Primitive] enum which denotes the type of value from Primitives enums
   final Primitive primitive;
   PrimitiveType({required this.primitive, super.path, super.docs})
@@ -63,7 +62,6 @@ class PrimitiveType extends Type with CodecType {
 ///
 /// CompactType
 class CompactType extends Type with CodecType {
-
   /// type which this Type denotes
   final int type;
   CompactType({required this.type, super.path, super.docs})
@@ -73,7 +71,6 @@ class CompactType extends Type with CodecType {
 ///
 /// SequenceType
 class SequenceType extends Type with CodecType {
-
   /// type which this sequence denotes
   final int type;
   SequenceType({required this.type, super.path, super.docs})
@@ -96,7 +93,6 @@ class BitSequenceType extends Type with CodecType {
 ///
 /// ArrayType
 class ArrayType extends Type with CodecType {
-
   /// length of this array
   final int length;
 
@@ -109,7 +105,6 @@ class ArrayType extends Type with CodecType {
 ///
 /// TupleType
 class TupleType extends Type with CodecType {
-
   /// [Optional] tuple
   final List<int> tuple;
   TupleType({this.tuple = const <int>[], super.path, super.docs})
@@ -119,7 +114,6 @@ class TupleType extends Type with CodecType {
 ///
 /// CompositeType
 class CompositeType extends Type with CodecType {
-
   /// [Optional] fields
   final List<Field> fields;
   CompositeType({this.fields = const <Field>[], super.path, super.docs})

--- a/packages/polkadart_scale_codec/lib/src/core/types.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/types.dart
@@ -53,11 +53,6 @@ enum Primitive {
 ///
 /// PrimitiveType
 class PrimitiveType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
 
   /// Value from [Primitive] enum which denotes the type of value from Primitives enums
   final Primitive primitive;
@@ -68,11 +63,6 @@ class PrimitiveType extends Type with CodecType {
 ///
 /// CompactType
 class CompactType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
 
   /// type which this Type denotes
   final int type;
@@ -83,11 +73,6 @@ class CompactType extends Type with CodecType {
 ///
 /// SequenceType
 class SequenceType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
 
   /// type which this sequence denotes
   final int type;
@@ -98,11 +83,6 @@ class SequenceType extends Type with CodecType {
 ///
 /// BitSequenceType
 class BitSequenceType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
   final int bitStoreType;
   final int bitOrderType;
   BitSequenceType(
@@ -116,11 +96,6 @@ class BitSequenceType extends Type with CodecType {
 ///
 /// ArrayType
 class ArrayType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
 
   /// length of this array
   final int length;
@@ -134,11 +109,6 @@ class ArrayType extends Type with CodecType {
 ///
 /// TupleType
 class TupleType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
 
   /// [Optional] tuple
   final List<int> tuple;
@@ -149,11 +119,6 @@ class TupleType extends Type with CodecType {
 ///
 /// CompositeType
 class CompositeType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
 
   /// [Optional] fields
   final List<Field> fields;
@@ -176,12 +141,6 @@ class Field {
 ///
 /// VariantType
 class VariantType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
-
   /// Variants it can hold
   final List<Variant> variants;
   VariantType({this.variants = const <Variant>[], super.path, super.docs})
@@ -210,12 +169,6 @@ class Variant {
 ///
 /// OptionType
 class OptionType extends Type with CodecType {
-  @override
-  List<String>? docs;
-
-  @override
-  List<String>? path;
-
   /// type which this Optional Value denotes
   final int type;
   OptionType({required this.type, super.path, super.docs})

--- a/packages/substrate_metadata/lib/event_registry.dart
+++ b/packages/substrate_metadata/lib/event_registry.dart
@@ -7,18 +7,13 @@ import 'utils/utils.dart';
 
 class Definition extends scale_codec.Variant {
   final String pallet;
-
-  @override
-  List<scale_codec.Field> fields;
-  @override
-  List<String>? docs;
-  Definition(
-      {this.fields = const <scale_codec.Field>[],
-      required int index,
-      required this.pallet,
-      required String name,
-      this.docs})
-      : super(fields: fields, docs: docs, index: index, name: name);
+  Definition({
+    super.fields = const <scale_codec.Field>[],
+    required super.index,
+    required this.pallet,
+    required super.name,
+    super.docs,
+  });
 }
 
 /// Event Registry

--- a/packages/substrate_metadata/lib/models/metadata/metadata_versions.dart
+++ b/packages/substrate_metadata/lib/models/metadata/metadata_versions.dart
@@ -3,9 +3,7 @@
 part of models;
 
 class Metadata_V9 extends Metadata {
-  @override
-  final MetadataV9 value;
-  const Metadata_V9({required this.value}) : super(kind: 'V9', value: value);
+  const Metadata_V9({super.value}) : super(kind: 'V9');
 
   /// Creates Class Object from `Json`
   static Metadata_V9 fromJson(Map<String, dynamic> map) =>
@@ -13,9 +11,7 @@ class Metadata_V9 extends Metadata {
 }
 
 class Metadata_V10 extends Metadata {
-  @override
-  final MetadataV10 value;
-  const Metadata_V10({required this.value}) : super(kind: 'V10', value: value);
+  const Metadata_V10({super.value}) : super(kind: 'V10');
 
   /// Creates Class Object from `Json`
   static Metadata_V10 fromJson(Map<String, dynamic> map) =>
@@ -23,9 +19,7 @@ class Metadata_V10 extends Metadata {
 }
 
 class Metadata_V11 extends Metadata {
-  @override
-  final MetadataV11 value;
-  const Metadata_V11({required this.value}) : super(kind: 'V11', value: value);
+  const Metadata_V11({super.value}) : super(kind: 'V11');
 
   /// Creates Class Object from `Json`
   static Metadata_V11 fromJson(Map<String, dynamic> map) =>
@@ -33,9 +27,7 @@ class Metadata_V11 extends Metadata {
 }
 
 class Metadata_V12 extends Metadata {
-  @override
-  final MetadataV12 value;
-  const Metadata_V12({required this.value}) : super(kind: 'V12', value: value);
+  const Metadata_V12({super.value}) : super(kind: 'V12');
 
   /// Creates Class Object from `Json`
   static Metadata_V12 fromJson(Map<String, dynamic> map) =>
@@ -43,9 +35,7 @@ class Metadata_V12 extends Metadata {
 }
 
 class Metadata_V13 extends Metadata {
-  @override
-  final MetadataV13 value;
-  const Metadata_V13({required this.value}) : super(kind: 'V13', value: value);
+  const Metadata_V13({super.value}) : super(kind: 'V13');
 
   /// Creates Class Object from `Json`
   static Metadata_V13 fromJson(Map<String, dynamic> map) =>
@@ -53,9 +43,7 @@ class Metadata_V13 extends Metadata {
 }
 
 class Metadata_V14 extends Metadata {
-  @override
-  final MetadataV14 value;
-  const Metadata_V14({required this.value}) : super(kind: 'V14', value: value);
+  const Metadata_V14({super.value}) : super(kind: 'V14');
 
   /// Creates Class Object from `Json`
   static Metadata_V14 fromJson(Map<String, dynamic> map) =>

--- a/packages/substrate_metadata/lib/models/module_metadata/module_metadata.dart
+++ b/packages/substrate_metadata/lib/models/module_metadata/module_metadata.dart
@@ -18,26 +18,15 @@ abstract class AnyLegacyModule {
 }
 
 class ModuleMetadataV9 extends AnyLegacyModule {
-  @override
-  final String name;
   StorageMetadataV9? storage;
-  @override
-  List<FunctionMetadataV9>? calls;
-  @override
-  List<EventMetadataV9>? events;
-  @override
-  List<ModuleConstantMetadataV9> constants;
-  @override
-  List<ErrorMetadataV9> errors;
 
   ModuleMetadataV9(
-      {required this.name,
+      {required super.name,
       this.storage,
       super.calls,
       super.events,
-      required this.constants,
-      required this.errors})
-      : super(name: name, constants: constants, errors: errors);
+      required super.constants,
+      required super.errors});
 
   /// Creates Class Object from `Json`
   static ModuleMetadataV9 fromJson(Map<String, dynamic> map) {
@@ -77,26 +66,15 @@ class ModuleMetadataV9 extends AnyLegacyModule {
 }
 
 class ModuleMetadataV10 extends AnyLegacyModule {
-  @override
-  final String name;
   StorageMetadataV10? storage;
-  @override
-  List<FunctionMetadataV9>? calls;
-  @override
-  List<EventMetadataV9>? events;
-  @override
-  final List<ModuleConstantMetadataV9> constants;
-  @override
-  final List<ErrorMetadataV9> errors;
 
   ModuleMetadataV10(
-      {required this.name,
+      {required super.name,
       this.storage,
       super.calls,
       super.events,
-      required this.constants,
-      required this.errors})
-      : super(name: name, constants: constants, errors: errors);
+      required super.constants,
+      required super.errors});
 
   /// Creates Class Object from `Json`
   static ModuleMetadataV10 fromJson(Map<String, dynamic> map) {
@@ -136,26 +114,15 @@ class ModuleMetadataV10 extends AnyLegacyModule {
 }
 
 class ModuleMetadataV11 extends AnyLegacyModule {
-  @override
-  final String name;
   StorageMetadataV11? storage;
-  @override
-  List<FunctionMetadataV9>? calls;
-  @override
-  List<EventMetadataV9>? events;
-  @override
-  List<ModuleConstantMetadataV9> constants;
-  @override
-  List<ErrorMetadataV9> errors;
 
   ModuleMetadataV11(
-      {required this.name,
+      {required super.name,
       this.storage,
       super.calls,
       super.events,
-      required this.constants,
-      required this.errors})
-      : super(name: name, constants: constants, errors: errors);
+      required super.constants,
+      required super.errors});
 
   /// Creates Class Object from `Json`
   static ModuleMetadataV11 fromJson(Map<String, dynamic> map) {
@@ -195,28 +162,17 @@ class ModuleMetadataV11 extends AnyLegacyModule {
 }
 
 class ModuleMetadataV12 extends AnyLegacyModule {
-  @override
-  final String name;
   final int index;
   StorageMetadataV11? storage;
-  @override
-  List<FunctionMetadataV9>? calls;
-  @override
-  List<EventMetadataV9>? events;
-  @override
-  List<ModuleConstantMetadataV9> constants;
-  @override
-  List<ErrorMetadataV9> errors;
 
   ModuleMetadataV12(
-      {required this.name,
+      {required super.name,
       required this.index,
       this.storage,
       super.calls,
       super.events,
-      required this.constants,
-      required this.errors})
-      : super(name: name, constants: constants, errors: errors);
+      required super.constants,
+      required super.errors});
 
   /// Creates Class Object from `Json`
   static ModuleMetadataV12 fromJson(Map<String, dynamic> map) {
@@ -257,28 +213,17 @@ class ModuleMetadataV12 extends AnyLegacyModule {
 }
 
 class ModuleMetadataV13 extends AnyLegacyModule {
-  @override
-  final String name;
   final int index;
   StorageMetadataV13? storage;
-  @override
-  List<FunctionMetadataV9>? calls;
-  @override
-  List<EventMetadataV9>? events;
-  @override
-  final List<ModuleConstantMetadataV9> constants;
-  @override
-  final List<ErrorMetadataV9> errors;
 
   ModuleMetadataV13(
-      {required this.name,
+      {required super.name,
       required this.index,
       this.storage,
       super.calls,
       super.events,
-      required this.constants,
-      required this.errors})
-      : super(name: name, constants: constants, errors: errors);
+      required super.constants,
+      required super.errors});
 
   /// Creates Class Object from `Json`
   static ModuleMetadataV13 fromJson(Map<String, dynamic> map) {

--- a/packages/substrate_metadata/lib/models/raw_block/raw_block.model.dart
+++ b/packages/substrate_metadata/lib/models/raw_block/raw_block.model.dart
@@ -44,9 +44,8 @@ class RawBlock extends RpcBlock implements Equatable {
   final int blockNumber;
   const RawBlock(
       {required this.blockNumber,
-      RpcBlockHeader? header,
-      required List<String> extrinsics})
-      : super(header: header, extrinsics: extrinsics);
+      super.header,
+      required super.extrinsics});
 
   static RawBlock fromJson(Map<String, dynamic> map) => RawBlock(
         blockNumber: map['blockNumber'],

--- a/packages/substrate_metadata/lib/models/raw_block/raw_block.model.dart
+++ b/packages/substrate_metadata/lib/models/raw_block/raw_block.model.dart
@@ -43,9 +43,7 @@ abstract class RpcBlock {
 class RawBlock extends RpcBlock implements Equatable {
   final int blockNumber;
   const RawBlock(
-      {required this.blockNumber,
-      super.header,
-      required super.extrinsics});
+      {required this.blockNumber, super.header, required super.extrinsics});
 
   static RawBlock fromJson(Map<String, dynamic> map) => RawBlock(
         blockNumber: map['blockNumber'],

--- a/packages/substrate_metadata/lib/models/storage/storage_entry_modifier.dart
+++ b/packages/substrate_metadata/lib/models/storage/storage_entry_modifier.dart
@@ -53,20 +53,16 @@ class StorageEntryTypeV14 {
 }
 
 class StorageEntryTypeV14_Plain extends StorageEntryTypeV14 {
-  @override
-  final int value;
-  const StorageEntryTypeV14_Plain({required this.value})
-      : super(kind: 'Plain', value: value);
+  const StorageEntryTypeV14_Plain({required super.value})
+      : super(kind: 'Plain');
 }
 
 class StorageEntryTypeV14_Map extends StorageEntryTypeV14 {
   final List<StorageHasherV11> hashers;
   final int key;
-  @override
-  final int value;
   const StorageEntryTypeV14_Map(
-      {required this.hashers, required this.key, required this.value})
-      : super(kind: 'Map', value: value);
+      {required this.hashers, required this.key, required super.value})
+      : super(kind: 'Map');
 
   /// Creates Class Object from `Json`
   static StorageEntryTypeV14_Map fromJson(Map<String, dynamic> map) =>


### PR DESCRIPTION
Why ?
- Important to remove duplication of variables.

Test
`dart test`