### PR TITLE
Era resolution #178

### DIFF
--- a/packages/polkadart_scale_codec/lib/src/core/registry.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/registry.dart
@@ -786,6 +786,8 @@ Primitive? asPrimitive(String name) {
       return Primitive.Str;
     case 'char':
       return Primitive.Char;
+    case 'extrinsicera':
+      return Primitive.ExtrinsicEra;
     default:
       return null;
   }

--- a/packages/polkadart_scale_codec/lib/src/core/types.dart
+++ b/packages/polkadart_scale_codec/lib/src/core/types.dart
@@ -48,6 +48,10 @@ enum Primitive {
 
   /// Single Character
   Char,
+
+  /// Mocking Extrinsic Era as primitive for quick fix.
+  /// TODO: Issue: #183 : Remove this quick-fix once Extrinsic Era is implemented in Generic Way
+  ExtrinsicEra,
 }
 
 ///

--- a/packages/polkadart_scale_codec/lib/src/util/functions.dart
+++ b/packages/polkadart_scale_codec/lib/src/util/functions.dart
@@ -276,3 +276,70 @@ int unsignedIntByteLength(BigInt value) {
   }
   return length;
 }
+
+///
+/// Converts little endian integer to hex
+/// [value] - little endian integer
+/// [length] - length of the integer
+/// Returns: `Uint8List`
+///
+/// Example:
+/// ```dart
+/// int value = 51;
+/// int length = 2;
+/// Uint8List hex = littleIntToHex(value, length);
+/// // hex = [51, 0]
+/// ```
+Uint8List littleIntToUint8List(int value, int length) {
+  final String val = value.toRadixString(2).padLeft(length * 8, '0');
+  final String flippedBits = flipBits(val);
+  final gmp = BigInt.parse(flippedBits, radix: 2)
+      .toRadixString(16)
+      .padLeft(length * 2, '0');
+  final buffer = Uint8List.fromList(decodeHex(gmp));
+  return buffer;
+}
+
+///
+/// Flips bits
+/// [bitString] - bit string
+/// Returns: `String`
+///
+/// Example:
+/// ```dart
+/// String bitString = '000000000000000000001010';
+/// String flippedBits = flipBits(bitString);
+/// // flippedBits = '101010000000000000000000'
+/// ```
+String flipBits(String bitString) {
+  final length = bitString.length;
+
+  if (length % 8 != 0) {
+    throw UnexpectedCaseException('Bit string length must be a multiple of 8');
+  }
+
+  var newString = '';
+  for (var i = length; i >= 0; i -= 8) {
+    newString += bitString.substring(i, (i + 8).clamp(0, length));
+  }
+
+  return newString;
+}
+
+///
+/// Counts the number of leading zeros in the binary representation of [value].
+///
+/// Example:
+/// ```dart
+/// int value = 1048576;
+/// int zero = countZeros(value);
+/// // zero = 20
+/// ```
+int countZeros(int value) {
+  var zero = 0;
+  while ((value & 1) == 0) {
+    zero += 1;
+    value = value >> 1;
+  }
+  return zero;
+}

--- a/packages/substrate_metadata/lib/chain_description/parse_v14.dart
+++ b/packages/substrate_metadata/lib/chain_description/parse_v14.dart
@@ -255,6 +255,24 @@ abstract class ParseV14 implements _$ParseV14 {
     List<Type> typesValue = metadata.lookup?.types.map((PortableTypeV14 t) {
           var info = {'path': t.type.path, 'docs': t.type.docs};
           var def = t.type.def;
+
+          /// TODO: Issue: #183 Replace this approach with a more generic one
+          ///
+          /// Why used? : (to get {"period": val, "phase": val})
+          if (t.type.def is Si1TypeDef_Composite &&
+              (t.type.def as Si1TypeDef_Composite).value.fields.isNotEmpty &&
+              (t.type.def as Si1TypeDef_Composite)
+                      .value
+                      .fields[0]
+                      .typeName
+                      ?.toLowerCase() ==
+                  'era') {
+            return PrimitiveType(
+              primitive: scale_codec.Primitive.ExtrinsicEra,
+              path: info['path'],
+              docs: info['docs'],
+            );
+          }
           switch (def.kind) {
             case 'Primitive':
               return PrimitiveType(

--- a/packages/substrate_metadata/lib/utils/utils.dart
+++ b/packages/substrate_metadata/lib/utils/utils.dart
@@ -88,9 +88,12 @@ extension ToJson<T> on T {
         toEncodable: (value) {
           if (value is BigInt) {
             return value.toString();
-          } else if (value is scale.Some || value is scale.NoneOption) {
+          } else if (value is scale.Some) {
             return value.toJson();
+          } else if (value is scale.NoneOption || value == scale.None) {
+            return {'_kind': 'None'};
           }
+
           return value;
         },
       );


### PR DESCRIPTION
## Any follow ups?
#180 

## Description
- A temporary fix to get `{"period": value, "phase": value}`.
- A issue is made to handle it in generic way: #183 
- Also improved `toHuman()` to handle `None` aka (`NoneOption`).

## Why?
#178 

## How?
- Done by manually extracting the era when making ChainDescription Types.
