### PR TITLE
Fix Dart Generator JsonType cache

### DIFF
--- a/packages/polkadart_cli/lib/src/generator/polkadart.dart
+++ b/packages/polkadart_cli/lib/src/generator/polkadart.dart
@@ -159,7 +159,8 @@ class PolkadartGenerator {
                 ..name = 'url'))
               ..body = Block.of([
                 declareFinal('provider')
-                    .assign(refs.provider.newInstance([refer('url')]))
+                    .assign(refs.provider
+                        .newInstanceNamed('fromUri', [refer('url')]))
                     .statement,
                 refer(name).newInstance([refer('provider')]).returned.statement,
               ])),

--- a/packages/polkadart_cli/lib/src/typegen/class_builder.dart
+++ b/packages/polkadart_cli/lib/src/typegen/class_builder.dart
@@ -20,7 +20,13 @@ import 'package:code_builder/code_builder.dart'
         literalString,
         refer;
 import './typegen.dart' as generators
-    show CompositeBuilder, Field, PrimitiveDescriptor, Variant, VariantBuilder;
+    show
+        CompositeBuilder,
+        Field,
+        PrimitiveDescriptor,
+        Variant,
+        VariantBuilder,
+        TypeBuilderContext;
 import './references.dart' as refs;
 import '../utils/utils.dart' show sanitizeDocs;
 
@@ -34,6 +40,7 @@ Class createCompositeClass(generators.CompositeBuilder compositeGenerator) =>
       final classType =
           TypeReference((b) => b..symbol = compositeGenerator.name);
       final codecType = refer(classToCodecName(compositeGenerator.name));
+      final builderContext = generators.TypeBuilderContext(from: dirname);
 
       classBuilder
         ..name = classType.symbol
@@ -59,7 +66,7 @@ Class createCompositeClass(generators.CompositeBuilder compositeGenerator) =>
           ..body = Code('return codec.encode(this);')))
         ..methods.add(Method((b) => b
           ..name = 'toJson'
-          ..returns = compositeGenerator.jsonType(dirname, {})
+          ..returns = builderContext.jsonTypeFrom(compositeGenerator)
           ..body = compositeGenerator.toJson(dirname).code))
         ..fields.addAll(compositeGenerator.fields.map((field) => Field((b) => b
           ..name = field.sanitizedName
@@ -386,6 +393,7 @@ Enum createSimpleVariantEnum(generators.VariantBuilder variant) =>
       final dirname = p.dirname(variant.filePath);
       final Reference typeRef = refer(variant.name);
       final Reference codecRef = refer(classToCodecName(variant.name));
+      final builderContext = generators.TypeBuilderContext(from: dirname);
 
       enumBuilder
         ..name = typeRef.symbol
@@ -408,7 +416,7 @@ Enum createSimpleVariantEnum(generators.VariantBuilder variant) =>
           ..body = Code('return codec.decode(input);')))
         ..methods.add(Method((b) => b
           ..name = 'toJson'
-          ..returns = variant.jsonType(dirname, {})
+          ..returns = builderContext.jsonTypeFrom(variant)
           ..body = refer('variantName').code))
         ..fields.addAll([
           Field((b) => b

--- a/packages/polkadart_cli/lib/src/typegen/typegen.dart
+++ b/packages/polkadart_cli/lib/src/typegen/typegen.dart
@@ -1,5 +1,6 @@
 library descriptors;
 
+import 'dart:collection' show HashMap;
 import 'package:code_builder/code_builder.dart'
     show
         Block,

--- a/packages/polkadart_cli/lib/src/typegen/types/array.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/array.dart
@@ -159,8 +159,7 @@ class ArrayDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     if (typeDef is PrimitiveDescriptor) {
       switch ((typeDef as PrimitiveDescriptor).primitiveType) {
         case metadata.Primitive.U8:
@@ -186,14 +185,10 @@ class ArrayDescriptor extends TypeDescriptor {
           break;
       }
     }
-    if (visited.contains(this)) {
+    if (isCircular) {
       return refs.list(ref: refs.dynamic);
     }
-    visited.add(this);
-    final type = TypeDescriptor.cacheOrCreate(
-        from, visited, () => refs.list(ref: typeDef.jsonType(from, visited)));
-    visited.remove(this);
-    return type;
+    return refs.list(ref: context.jsonTypeFrom(typeDef));
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/bit_sequence.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/bit_sequence.dart
@@ -78,7 +78,7 @@ class BitSequenceDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from, [Set<Object> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     return refs.list(ref: refs.int);
   }
 

--- a/packages/polkadart_cli/lib/src/typegen/types/btreemap.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/btreemap.dart
@@ -63,19 +63,12 @@ class BTreeMapDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
-    if (visited.contains(this)) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
+    if (isCircular) {
       return refs.map(refs.dynamic, refs.dynamic);
     }
-    visited.add(this);
-    final type = TypeDescriptor.cacheOrCreate(
-        from,
-        visited,
-        () => refs.map(
-            key.jsonType(from, visited), value.jsonType(from, visited)));
-    visited.remove(this);
-    return type;
+
+    return refs.map(context.jsonTypeFrom(key), context.jsonTypeFrom(value));
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/compact.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/compact.dart
@@ -24,7 +24,7 @@ class CompactDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from, [Set<Object> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     return refs.bigInt.type as TypeReference;
   }
 

--- a/packages/polkadart_cli/lib/src/typegen/types/empty.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/empty.dart
@@ -23,8 +23,7 @@ class EmptyDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     return refs.dynamic.type as TypeReference;
   }
 

--- a/packages/polkadart_cli/lib/src/typegen/types/option.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/option.dart
@@ -61,23 +61,18 @@ class OptionDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
-    if (visited.contains(this)) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
+    if (isCircular) {
       return refs.dynamic.type as TypeReference;
     }
-    visited.add(this);
-    final newType = TypeDescriptor.cacheOrCreate(from, visited, () {
-      if (inner is OptionDescriptor) {
-        return refs.map(
-          refs.string,
-          inner.jsonType(from, visited).asNullable(),
-        );
-      }
-      return inner.jsonType(from, visited).asNullable();
-    });
-    visited.remove(this);
-    return newType;
+    final innerJsonType = context.jsonTypeFrom(inner).asNullable();
+    if (inner is OptionDescriptor) {
+      return refs.map(
+        refs.string,
+        innerJsonType,
+      );
+    }
+    return innerJsonType;
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/primitive.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/primitive.dart
@@ -146,8 +146,7 @@ class PrimitiveDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     switch (primitiveType) {
       case metadata.Primitive.Bool:
         return refs.bool.type as TypeReference;

--- a/packages/polkadart_cli/lib/src/typegen/types/result.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/result.dart
@@ -57,8 +57,7 @@ class ResultDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     return refs.map(refs.string, refs.dynamic);
   }
 

--- a/packages/polkadart_cli/lib/src/typegen/types/sequence.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/sequence.dart
@@ -154,8 +154,7 @@ class SequenceDescriptor extends TypeDescriptor {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     if (typeDef is PrimitiveDescriptor) {
       switch ((typeDef as PrimitiveDescriptor).primitiveType) {
         case metadata.Primitive.U8:
@@ -181,13 +180,10 @@ class SequenceDescriptor extends TypeDescriptor {
           break;
       }
     }
-    if (visited.contains(this)) {
+    if (isCircular) {
       return refs.list(ref: refs.dynamic);
     }
-    visited.add(this);
-    final newType = refs.list(ref: typeDef.jsonType(from, visited));
-    visited.remove(this);
-    return newType;
+    return refs.list(ref: context.jsonTypeFrom(typeDef));
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/tuple.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/tuple.dart
@@ -67,23 +67,18 @@ class TupleBuilder extends TypeBuilder {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
     if (generators.isEmpty) {
       return refs.dynamic.type as TypeReference;
     }
 
-    if (visited.contains(this)) {
+    if (isCircular) {
       return refs.list(ref: refs.dynamic);
     }
-    visited.add(this);
-
     // Check if all fields are of the same type, otherwise use dynamic
     final type = findCommonType(
-        generators.map((generator) => generator.jsonType(from, visited)));
-    final newType = refs.list(ref: type);
-    visited.remove(this);
-    return newType;
+        generators.map((generator) => context.jsonTypeFrom(generator)));
+    return refs.list(ref: type);
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
@@ -67,15 +67,8 @@ class TypeDefBuilder extends TypeBuilder {
   }
 
   @override
-  TypeReference jsonType(BasePath from,
-      [Set<TypeDescriptor> visited = const {}]) {
-    if (visited.contains(this)) {
-      return refs.dynamic.type as TypeReference;
-    }
-    visited.add(this);
-    final newType = generator.jsonType(from, visited);
-    visited.remove(this);
-    return newType;
+  TypeReference jsonType(bool isCircular, TypeBuilderContext context) {
+    return generator.jsonType(isCircular, context);
   }
 
   @override


### PR DESCRIPTION
This PR fixes in the generator cache

# Bug
Due some `cacheKey` collisions, the Dart Generator was producing the wrong output for some chains, now we are using the substrate-metadata type id as cache key, which also improves the performance.
