### PR TITLE
Override object equality operator and hashcode

### DIFF
--- a/packages/polkadart_cli/lib/src/typegen/class_builder.dart
+++ b/packages/polkadart_cli/lib/src/typegen/class_builder.dart
@@ -621,54 +621,6 @@ Class createSimpleVariantCodec(
               .statement));
     });
 
-Class createTypeDefCodec(
-  generators.TypeDefBuilder typeDef,
-) =>
-    Class((classBuilder) {
-      final className = refer(typeDef.name);
-      final dirname = p.dirname(typeDef.filePath);
-
-      classBuilder
-        ..name = '${typeDef.name}Codec'
-        ..constructors.add(Constructor((b) => b..constant = true))
-        ..mixins.add(refs.codec(ref: className))
-        ..methods.add(Method((b) => b
-          ..name = 'decode'
-          ..returns = className
-          ..annotations.add(refer('override'))
-          ..requiredParameters.add(Parameter((b) => b
-            ..type = refs.input
-            ..name = 'input'))
-          ..body = typeDef.generator.decode(dirname).returned.statement))
-        ..methods.add(Method.returnsVoid((b) => b
-          ..name = 'encodeTo'
-          ..annotations.add(refer('override'))
-          ..requiredParameters.addAll([
-            Parameter((b) => b
-              ..type = className
-              ..name = 'value'),
-            Parameter((b) => b
-              ..type = refs.output
-              ..name = 'output'),
-          ])
-          ..body = typeDef.generator.encode(dirname, refer('value')).statement))
-        ..methods.add(Method((b) => b
-          ..name = 'sizeHint'
-          ..returns = refs.int
-          ..annotations.add(refer('override'))
-          ..requiredParameters.add(
-            Parameter((b) => b
-              ..type = className
-              ..name = 'value'),
-          )
-          ..body = typeDef.generator
-              .codecInstance(dirname)
-              .property('sizeHint')
-              .call([refer('value')])
-              .returned
-              .statement));
-    });
-
 Class createTupleClass(
   int size,
 ) =>

--- a/packages/polkadart_cli/lib/src/typegen/class_builder.dart
+++ b/packages/polkadart_cli/lib/src/typegen/class_builder.dart
@@ -23,6 +23,7 @@ import 'package:code_builder/code_builder.dart'
         refer;
 import './typegen.dart' as generators
     show
+        BTreeMapDescriptor,
         CompositeBuilder,
         SequenceDescriptor,
         ArrayDescriptor,
@@ -53,6 +54,15 @@ Method overrideEqualsMethod(
     if (codec is generators.SequenceDescriptor ||
         codec is generators.ArrayDescriptor) {
       body = body.and(refs.quiverListsEqual.call([
+        refer('other').property(fieldname),
+        refer(fieldname == 'other' ? 'this.other' : fieldname),
+      ]));
+      continue;
+    }
+
+    // Compare two maps using quiver
+    if (codec is generators.BTreeMapDescriptor) {
+      body = body.and(refs.quiverMapsEqual.call([
         refer('other').property(fieldname),
         refer(fieldname == 'other' ? 'this.other' : fieldname),
       ]));

--- a/packages/polkadart_cli/lib/src/typegen/parser.dart
+++ b/packages/polkadart_cli/lib/src/typegen/parser.dart
@@ -222,7 +222,8 @@ Map<int, TypeDescriptor> parseTypes(
                   loader: lazyLoader,
                   codec: field.type,
                   docs: field.docs,
-                  name: field.name))
+                  name: field.name,
+                  rustTypeName: field.typeName))
               .toList());
       continue;
     }
@@ -305,6 +306,7 @@ Map<int, TypeDescriptor> parseTypes(
                           codec: field.type,
                           name: field.name,
                           docs: field.docs,
+                          rustTypeName: field.typeName,
                         ))
                     .toList());
           }).toList());

--- a/packages/polkadart_cli/lib/src/typegen/parser.dart
+++ b/packages/polkadart_cli/lib/src/typegen/parser.dart
@@ -286,7 +286,7 @@ Map<int, TypeDescriptor> parseTypes(
           id: type.id,
           filePath: listToFilePath([typesPath, ...type.path]),
           name: enumName,
-          orginalName: type.path.last,
+          originalName: type.path.last,
           docs: type.docs,
           variants: variant.variants.map((variant) {
             String variantName = sanitizeClassName(variant.name,
@@ -296,7 +296,7 @@ Map<int, TypeDescriptor> parseTypes(
             }
             return Variant(
                 name: variantName,
-                orignalName: variant.name,
+                originalName: variant.name,
                 index: variant.index,
                 docs: variant.docs,
                 fields: variant.fields

--- a/packages/polkadart_cli/lib/src/typegen/references.dart
+++ b/packages/polkadart_cli/lib/src/typegen/references.dart
@@ -330,3 +330,6 @@ TypeReference storageSextupleMap(
 ////////////
 const quiverListsEqual =
     Reference('listsEqual', 'package:quiver/collection.dart');
+
+const quiverMapsEqual =
+    Reference('mapsEqual', 'package:quiver/collection.dart');

--- a/packages/polkadart_cli/lib/src/typegen/references.dart
+++ b/packages/polkadart_cli/lib/src/typegen/references.dart
@@ -33,6 +33,8 @@ const bool = Reference('bool', 'dart:core');
 const dynamic = Reference('dynamic');
 const int = Reference('int', 'dart:core');
 const void_ = Reference('void', 'dart:core');
+const object = Reference('Object', 'dart:core');
+const identical = Reference('identical', 'dart:core');
 const string = Reference('String', 'dart:core');
 const uri = Reference('Uri', 'dart:core');
 const bigInt = Reference('BigInt', 'dart:core');
@@ -322,3 +324,9 @@ TypeReference storageSextupleMap(
     ..url = 'package:polkadart/polkadart.dart'
     ..types.addAll([key1, key2, key3, key4, key5, key6, value]));
 }
+
+////////////
+// Quiver //
+////////////
+const quiverListsEqual =
+    Reference('listsEqual', 'package:quiver/collection.dart');

--- a/packages/polkadart_cli/lib/src/typegen/typegen.dart
+++ b/packages/polkadart_cli/lib/src/typegen/typegen.dart
@@ -7,6 +7,7 @@ import 'package:code_builder/code_builder.dart'
         Class,
         Code,
         CodeExpression,
+        Constructor,
         DartEmitter,
         Enum,
         Expression,

--- a/packages/polkadart_cli/lib/src/typegen/typegen.dart
+++ b/packages/polkadart_cli/lib/src/typegen/typegen.dart
@@ -10,6 +10,7 @@ import 'package:code_builder/code_builder.dart'
         DartEmitter,
         Enum,
         Expression,
+        ExpressionVisitor,
         Library,
         Method,
         Parameter,

--- a/packages/polkadart_cli/lib/src/typegen/typegen.dart
+++ b/packages/polkadart_cli/lib/src/typegen/typegen.dart
@@ -75,7 +75,8 @@ import '../utils/utils.dart'
         findCommonType,
         listToFilePath,
         sanitize,
-        sanitizeClassName;
+        sanitizeClassName,
+        sanitizeDocs;
 import './class_builder.dart' as classbuilder;
 import './runtime_metadata_v14.dart' as metadata;
 import './references.dart' as refs;

--- a/packages/polkadart_cli/lib/src/typegen/types/array.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/array.dart
@@ -100,21 +100,21 @@ class ArrayDescriptor extends TypeDescriptor {
     ]);
   }
 
-  Expression listToExpression(List<int> values, bool constant) {
+  LiteralValue listToExpression(List<int> values, bool constant) {
     final TypeReference listType = refs.list(ref: refs.int);
     if (!constant && values.every((value) => value == 0)) {
       return listType.newInstanceNamed(
           'filled',
           [literalNum(values.length), literalNum(0)],
-          {'growable': literalFalse});
+          {'growable': literalFalse}).asLiteralValue();
     } else if (constant) {
-      return literalConstList(values, refs.int);
+      return literalConstList(values, refs.int).asLiteralConstant();
     }
-    return literalList(values, refs.int);
+    return literalList(values, refs.int).asLiteralValue();
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     if (typeDef is PrimitiveDescriptor) {
       switch ((typeDef as PrimitiveDescriptor).primitiveType) {
         case metadata.Primitive.U8:
@@ -147,15 +147,16 @@ class ArrayDescriptor extends TypeDescriptor {
       }
     }
 
-    final values = <Expression>[
+    final values = <LiteralValue>[
       for (int i = 0; i < length; i++)
         typeDef.valueFrom(from, input, constant: constant)
     ];
 
-    if (values.every((value) => value.isConst)) {
-      return literalConstList(values);
+    if (values.every((value) => value.isConstant)) {
+      return literalConstList(values.map((v) => v.expression).toList())
+          .asLiteralConstant();
     }
-    return literalList(values);
+    return literalList(values).asLiteralValue();
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/array.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/array.dart
@@ -108,7 +108,8 @@ class ArrayDescriptor extends TypeDescriptor {
           [literalNum(values.length), literalNum(0)],
           {'growable': literalFalse}).asLiteralValue();
     } else if (constant) {
-      return literalConstList(values, refs.int).asLiteralConstant();
+      return literalConstList(values, refs.int)
+          .asLiteralValue(isConstant: true);
     }
     return literalList(values, refs.int).asLiteralValue();
   }
@@ -152,9 +153,8 @@ class ArrayDescriptor extends TypeDescriptor {
         typeDef.valueFrom(from, input, constant: constant)
     ];
 
-    if (values.every((value) => value.isConstant)) {
-      return literalConstList(values.map((v) => v.expression).toList())
-          .asLiteralConstant();
+    if (constant && values.every((value) => value.isConstant)) {
+      return literalConstList(values).asLiteralValue(isConstant: true);
     }
     return literalList(values).asLiteralValue();
   }

--- a/packages/polkadart_cli/lib/src/typegen/types/bit_sequence.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/bit_sequence.dart
@@ -67,14 +67,14 @@ class BitSequenceDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     final bitArray = BitSequenceCodec(store, order).decode(input);
     return primitive(from).property('fromByteBuffer').call([
       literalNum(bitArray.length),
       refs.uint32List.property('fromList').call([
         literalConstList(bitArray.asUint32Iterable().toList())
       ]).property('buffer'),
-    ]);
+    ]).asLiteralValue();
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/btreemap.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/btreemap.dart
@@ -59,7 +59,7 @@ class BTreeMapDescriptor extends TypeDescriptor {
         map.values.every((value) => value.isConstant) &&
         map.keys.every((key) => key.isConstant)) {
       return literalConstMap(map, key.primitive(from), value.primitive(from))
-          .asLiteralConstant();
+          .asLiteralValue(isConstant: true);
     }
     return literalMap(map, key.primitive(from), value.primitive(from))
         .asLiteralValue();

--- a/packages/polkadart_cli/lib/src/typegen/types/btreemap.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/btreemap.dart
@@ -48,18 +48,21 @@ class BTreeMapDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     final size = CompactCodec.codec.decode(input);
-    final Map<Expression, Expression> map = {
+    final Map<LiteralValue, LiteralValue> map = {
       for (var i = 0; i < size; i++)
         key.valueFrom(from, input, constant: constant):
             value.valueFrom(from, input, constant: constant)
     };
-    if (map.values.every((value) => value.isConst) &&
-        map.keys.every((key) => key.isConst)) {
-      return literalConstMap(map, key.primitive(from), value.primitive(from));
+    if (constant &&
+        map.values.every((value) => value.isConstant) &&
+        map.keys.every((key) => key.isConstant)) {
+      return literalConstMap(map, key.primitive(from), value.primitive(from))
+          .asLiteralConstant();
     }
-    return literalMap(map, key.primitive(from), value.primitive(from));
+    return literalMap(map, key.primitive(from), value.primitive(from))
+        .asLiteralValue();
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/compact.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/compact.dart
@@ -18,9 +18,9 @@ class CompactDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     final value = CompactBigIntCodec.codec.decode(input);
-    return bigIntToExpression(value);
+    return bigIntToExpression(value).asLiteralValue();
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/composite.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/composite.dart
@@ -46,7 +46,7 @@ class CompositeBuilder extends TypeBuilder {
   @override
   LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     if (fields.isEmpty) {
-      return literalNull.asLiteralConstant();
+      return literalNull.asLiteralValue(isConstant: true);
     }
 
     final args = CallArguments.fromFields(fields,
@@ -55,7 +55,7 @@ class CompositeBuilder extends TypeBuilder {
     if (constant && args.every((value) => value.isConstant)) {
       return primitive(from)
           .constInstance(args.positional, args.named)
-          .asLiteralConstant();
+          .asLiteralValue(isConstant: true);
     }
 
     return primitive(from)

--- a/packages/polkadart_cli/lib/src/typegen/types/core.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/core.dart
@@ -31,7 +31,7 @@ abstract class TypeDescriptor {
     return codec(from).property('codec');
   }
 
-  Expression valueFrom(BasePath from, Input input, {bool constant = false});
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false});
 
   TypeReference jsonType(bool isCircular, TypeBuilderContext context);
 
@@ -169,5 +169,204 @@ class TypeBuilderContext {
       _isCircular = false;
     }
     return jsonType;
+  }
+}
+
+class _CallArgumentsIterator<T> implements Iterator<T> {
+  Iterator<T>? _positionalIterator;
+  final Iterator<T> _namedIterator;
+
+  _CallArgumentsIterator(this._positionalIterator, this._namedIterator);
+
+  @override
+  T get current {
+    if (_positionalIterator != null) {
+      return _positionalIterator!.current;
+    }
+    return _namedIterator.current;
+  }
+
+  @override
+  bool moveNext() {
+    if (_positionalIterator != null) {
+      if (!_positionalIterator!.moveNext()) {
+        _positionalIterator = null;
+      } else {
+        return true;
+      }
+    }
+    return _namedIterator.moveNext();
+  }
+}
+
+class CallArguments<T> extends Iterable<T> {
+  final List<T> positional;
+  final Map<String, T> named;
+
+  const CallArguments(this.positional, this.named);
+
+  factory CallArguments.fromFields(List<Field> fields, T Function(Field) map) {
+    final positionalArguments = <T>[];
+    final namedArguments = <String, T>{};
+    for (final field in fields) {
+      if (field.originalName != null) {
+        namedArguments[field.sanitizedName] = map(field);
+      } else {
+        positionalArguments.add(map(field));
+      }
+    }
+    return CallArguments(positionalArguments, namedArguments);
+  }
+
+  @override
+  Iterator<T> get iterator {
+    // final List<T> list = List.from(positional);
+    // list.addAll(named.values);
+    // return list.iterator;
+    return _CallArgumentsIterator(positional.iterator, named.values.iterator);
+  }
+}
+
+class LiteralValue<E extends Expression> extends Expression {
+  final E _expression;
+  final bool isConstant;
+
+  const LiteralValue(this._expression, {this.isConstant = false});
+
+  @override
+  bool get isConst => _expression.isConst || isConstant;
+
+  @override
+  R accept<R>(covariant ExpressionVisitor<R> visitor, [R? context]) =>
+      _expression.accept(visitor, context);
+
+  @override
+  Code get code => _expression.code;
+
+  @override
+  Code get statement => _expression.statement;
+
+  @override
+  Expression and(Expression other) => _expression.and(other);
+
+  @override
+  Expression or(Expression other) => _expression.or(other);
+
+  @override
+  Expression negate() => _expression.negate();
+
+  @override
+  Expression asA(Expression other) => _expression.asA(other);
+
+  @override
+  Expression index(Expression index) => _expression.index(index);
+
+  @override
+  Expression isA(Expression other) => _expression.isA(other);
+
+  @override
+  Expression isNotA(Expression other) => _expression.isNotA(other);
+
+  @override
+  Expression equalTo(Expression other) => _expression.equalTo(other);
+
+  @override
+  Expression notEqualTo(Expression other) => _expression.notEqualTo(other);
+
+  @override
+  Expression greaterThan(Expression other) => _expression.greaterThan(other);
+
+  @override
+  Expression lessThan(Expression other) => _expression.lessThan(other);
+
+  @override
+  Expression greaterOrEqualTo(Expression other) =>
+      _expression.greaterOrEqualTo(other);
+
+  @override
+  Expression lessOrEqualTo(Expression other) =>
+      _expression.lessOrEqualTo(other);
+
+  @override
+  Expression operatorAdd(Expression other) => _expression.operatorAdd(other);
+
+  @override
+  Expression operatorSubstract(Expression other) =>
+      _expression.operatorSubstract(other);
+
+  @override
+  Expression operatorDivide(Expression other) =>
+      _expression.operatorDivide(other);
+
+  @override
+  Expression operatorMultiply(Expression other) =>
+      _expression.operatorMultiply(other);
+
+  @override
+  Expression operatorEuclideanModulo(Expression other) =>
+      _expression.operatorEuclideanModulo(other);
+
+  @override
+  Expression conditional(Expression whenTrue, Expression whenFalse) =>
+      _expression.conditional(whenTrue, whenFalse);
+
+  @override
+  Expression get awaited => _expression.awaited;
+
+  @override
+  Expression assign(Expression other) => _expression.assign(other);
+
+  @override
+  Expression ifNullThen(Expression other) => _expression.ifNullThen(other);
+
+  @override
+  Expression assignNullAware(Expression other) =>
+      _expression.assignNullAware(other);
+
+  @override
+  Expression call(
+    Iterable<Expression> positionalArguments, [
+    Map<String, Expression> namedArguments = const {},
+    List<Reference> typeArguments = const [],
+  ]) =>
+      _expression.call(positionalArguments, namedArguments, typeArguments);
+
+  @override
+  Expression property(String name) => _expression.property(name);
+
+  @override
+  Expression cascade(String name) => _expression.cascade(name);
+
+  @override
+  Expression nullSafeProperty(String name) =>
+      _expression.nullSafeProperty(name);
+
+  @override
+  Expression get nullChecked => _expression.nullChecked;
+
+  @override
+  Expression get returned => _expression.returned;
+
+  @override
+  Expression get spread => _expression.spread;
+
+  @override
+  Expression get nullSafeSpread => _expression.nullSafeSpread;
+
+  @override
+  Expression get thrown => _expression.thrown;
+
+  @override
+  Expression get expression => _expression;
+}
+
+/// Helper to make a type nullable
+extension LiteralValueExtension on Expression {
+  LiteralValue asLiteralConstant() {
+    return LiteralValue(this, isConstant: true);
+  }
+
+  LiteralValue asLiteralValue({isConstant = false}) {
+    return LiteralValue(this, isConstant: isConstant);
   }
 }

--- a/packages/polkadart_cli/lib/src/typegen/types/core.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/core.dart
@@ -63,7 +63,7 @@ class GeneratedOutput {
       ..body.addAll(classes));
 
     final code = library3
-        .accept(DartEmitter.scoped(useNullSafetySyntax: true))
+        .accept(DartEmitter.scoped(useNullSafetySyntax: true, orderDirectives: true))
         .toString();
     try {
       return _dartfmt.format(code);

--- a/packages/polkadart_cli/lib/src/typegen/types/core.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/core.dart
@@ -91,12 +91,26 @@ class LazyLoader {
 }
 
 class Field {
+  /// The name of the field. None for unnamed fields.
   late String? originalName;
+
+  /// Dart sanitized name of the field, default to `value${index}` for unnamed fields.
   late String sanitizedName;
+
+  /// The type of the field.
   late TypeDescriptor codec;
+
+  /// Documentation
   late List<String> docs;
 
-  Field({required this.originalName, required this.codec, required this.docs}) {
+  /// The name of the type of the field as it appears in the source code.
+  late String? rustTypeName;
+
+  Field(
+      {required this.originalName,
+      required this.codec,
+      required this.docs,
+      this.rustTypeName}) {
     // TODO: detect collisions
     // ex: 'foo_bar' and `fooBar` will collide
     if (originalName != null) {
@@ -104,7 +118,7 @@ class Field {
     }
   }
 
-  Field._lazy({required String? name, required this.docs}) {
+  Field._lazy({required String? name, required this.docs, this.rustTypeName}) {
     originalName = name;
     if (originalName != null) {
       sanitizedName = toFieldName(originalName!);
@@ -116,8 +130,10 @@ class Field {
     required int codec,
     required String? name,
     List<String> docs = const [],
+    String? rustTypeName,
   }) {
-    final field = Field._lazy(name: name, docs: docs);
+    final field =
+        Field._lazy(name: name, docs: docs, rustTypeName: rustTypeName);
     loader.addLoader((Map<int, TypeDescriptor> register) {
       field.codec = register[codec]!;
     });

--- a/packages/polkadart_cli/lib/src/typegen/types/core.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/core.dart
@@ -63,7 +63,8 @@ class GeneratedOutput {
       ..body.addAll(classes));
 
     final code = library3
-        .accept(DartEmitter.scoped(useNullSafetySyntax: true, orderDirectives: true))
+        .accept(DartEmitter.scoped(
+            useNullSafetySyntax: true, orderDirectives: true))
         .toString();
     try {
       return _dartfmt.format(code);

--- a/packages/polkadart_cli/lib/src/typegen/types/empty.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/empty.dart
@@ -19,7 +19,7 @@ class EmptyDescriptor extends TypeDescriptor {
 
   @override
   LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
-    return literalNull.asLiteralConstant();
+    return literalNull.asLiteralValue(isConstant: true);
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/empty.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/empty.dart
@@ -18,8 +18,8 @@ class EmptyDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
-    return literalNull;
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
+    return literalNull.asLiteralConstant();
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/option.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/option.dart
@@ -42,19 +42,26 @@ class OptionDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     if (inner is OptionDescriptor || inner.primitive(from).isNullable == true) {
       if (input.read() == 0) {
-        return refs.option(inner.primitive(from)).newInstanceNamed('none', []);
+        return refs
+            .option(inner.primitive(from))
+            .newInstanceNamed('none', []).asLiteralConstant();
       } else {
-        return refs.option(inner.primitive(from)).newInstanceNamed('some', [
-          inner.valueFrom(from, input),
+        final innerValue = inner.valueFrom(from, input);
+        final expression =
+            refs.option(inner.primitive(from)).newInstanceNamed('some', [
+          innerValue,
         ]);
+        return constant && innerValue.isConstant
+            ? expression.asLiteralConstant()
+            : expression.asLiteralValue();
       }
     }
 
     if (input.read() == 0) {
-      return literalNull;
+      return literalNull.asLiteralConstant();
     } else {
       return inner.valueFrom(from, input);
     }

--- a/packages/polkadart_cli/lib/src/typegen/types/option.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/option.dart
@@ -47,21 +47,17 @@ class OptionDescriptor extends TypeDescriptor {
       if (input.read() == 0) {
         return refs
             .option(inner.primitive(from))
-            .newInstanceNamed('none', []).asLiteralConstant();
+            .newInstanceNamed('none', []).asLiteralValue(isConstant: true);
       } else {
         final innerValue = inner.valueFrom(from, input);
-        final expression =
-            refs.option(inner.primitive(from)).newInstanceNamed('some', [
+        return refs.option(inner.primitive(from)).newInstanceNamed('some', [
           innerValue,
-        ]);
-        return constant && innerValue.isConstant
-            ? expression.asLiteralConstant()
-            : expression.asLiteralValue();
+        ]).asLiteralValue(isConstant: constant && innerValue.isConstant);
       }
     }
 
     if (input.read() == 0) {
-      return literalNull.asLiteralConstant();
+      return literalNull.asLiteralValue(isConstant: true);
     } else {
       return inner.valueFrom(from, input);
     }

--- a/packages/polkadart_cli/lib/src/typegen/types/primitive.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/primitive.dart
@@ -109,37 +109,43 @@ class PrimitiveDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {constant = false}) {
     switch (primitiveType) {
       case metadata.Primitive.Bool:
-        return literalBool(BoolCodec.codec.decode(input));
+        return literalBool(BoolCodec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.Str:
-        return literalString(StrCodec.codec.decode(input));
+        return literalString(StrCodec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.Char:
       case metadata.Primitive.U8:
-        return literalNum(U8Codec.codec.decode(input));
+        return literalNum(U8Codec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.U16:
-        return literalNum(U16Codec.codec.decode(input));
+        return literalNum(U16Codec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.U32:
-        return literalNum(U32Codec.codec.decode(input));
+        return literalNum(U32Codec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.U64:
-        return bigIntToExpression(U64Codec.codec.decode(input));
+        return bigIntToExpression(U64Codec.codec.decode(input))
+            .asLiteralValue();
       case metadata.Primitive.U128:
-        return bigIntToExpression(U128Codec.codec.decode(input));
+        return bigIntToExpression(U128Codec.codec.decode(input))
+            .asLiteralValue();
       case metadata.Primitive.U256:
-        return bigIntToExpression(U256Codec.codec.decode(input));
+        return bigIntToExpression(U256Codec.codec.decode(input))
+            .asLiteralValue();
       case metadata.Primitive.I8:
-        return literalNum(I8Codec.codec.decode(input));
+        return literalNum(I8Codec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.I16:
-        return literalNum(I16Codec.codec.decode(input));
+        return literalNum(I16Codec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.I32:
-        return literalNum(I32Codec.codec.decode(input));
+        return literalNum(I32Codec.codec.decode(input)).asLiteralConstant();
       case metadata.Primitive.I64:
-        return bigIntToExpression(I64Codec.codec.decode(input));
+        return bigIntToExpression(I64Codec.codec.decode(input))
+            .asLiteralValue();
       case metadata.Primitive.I128:
-        return bigIntToExpression(I128Codec.codec.decode(input));
+        return bigIntToExpression(I128Codec.codec.decode(input))
+            .asLiteralValue();
       case metadata.Primitive.I256:
-        return bigIntToExpression(I256Codec.codec.decode(input));
+        return bigIntToExpression(I256Codec.codec.decode(input))
+            .asLiteralValue();
       default:
         throw Exception('Unsupported primitive $primitive');
     }

--- a/packages/polkadart_cli/lib/src/typegen/types/primitive.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/primitive.dart
@@ -112,16 +112,21 @@ class PrimitiveDescriptor extends TypeDescriptor {
   LiteralValue valueFrom(BasePath from, Input input, {constant = false}) {
     switch (primitiveType) {
       case metadata.Primitive.Bool:
-        return literalBool(BoolCodec.codec.decode(input)).asLiteralConstant();
+        return literalBool(BoolCodec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.Str:
-        return literalString(StrCodec.codec.decode(input)).asLiteralConstant();
+        return literalString(StrCodec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.Char:
       case metadata.Primitive.U8:
-        return literalNum(U8Codec.codec.decode(input)).asLiteralConstant();
+        return literalNum(U8Codec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.U16:
-        return literalNum(U16Codec.codec.decode(input)).asLiteralConstant();
+        return literalNum(U16Codec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.U32:
-        return literalNum(U32Codec.codec.decode(input)).asLiteralConstant();
+        return literalNum(U32Codec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.U64:
         return bigIntToExpression(U64Codec.codec.decode(input))
             .asLiteralValue();
@@ -132,11 +137,14 @@ class PrimitiveDescriptor extends TypeDescriptor {
         return bigIntToExpression(U256Codec.codec.decode(input))
             .asLiteralValue();
       case metadata.Primitive.I8:
-        return literalNum(I8Codec.codec.decode(input)).asLiteralConstant();
+        return literalNum(I8Codec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.I16:
-        return literalNum(I16Codec.codec.decode(input)).asLiteralConstant();
+        return literalNum(I16Codec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.I32:
-        return literalNum(I32Codec.codec.decode(input)).asLiteralConstant();
+        return literalNum(I32Codec.codec.decode(input))
+            .asLiteralValue(isConstant: true);
       case metadata.Primitive.I64:
         return bigIntToExpression(I64Codec.codec.decode(input))
             .asLiteralValue();

--- a/packages/polkadart_cli/lib/src/typegen/types/result.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/result.dart
@@ -40,14 +40,17 @@ class ResultDescriptor extends TypeDescriptor {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {constant = false}) {
-    if (input.read() == 0) {
-      return primitive(from)
-          .newInstanceNamed('ok', [ok.valueFrom(from, input)]);
+  LiteralValue valueFrom(BasePath from, Input input, {constant = false}) {
+    final bool isOk = input.read() == 0;
+    LiteralValue value;
+    if (isOk) {
+      value = ok.valueFrom(from, input);
     } else {
-      return primitive(from)
-          .newInstanceNamed('err', [err.valueFrom(from, input)]);
+      value = err.valueFrom(from, input);
     }
+    return primitive(from)
+        .newInstanceNamed(isOk ? 'ok' : 'err', [value]).asLiteralValue(
+            isConstant: constant && value.isConstant);
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/tuple.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/tuple.dart
@@ -54,16 +54,18 @@ class TupleBuilder extends TypeBuilder {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
-    final values = <Expression>[
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
+    final values = <LiteralValue>[
       for (final generator in generators)
         generator.valueFrom(from, input, constant: constant)
     ];
 
-    if (values.every((value) => value.isConst)) {
-      return primitive(from).constInstance(values);
+    if (constant && values.every((value) => value.isConstant)) {
+      return primitive(from)
+          .constInstance(values)
+          .asLiteralValue(isConstant: true);
     }
-    return primitive(from).newInstance(values);
+    return primitive(from).newInstance(values).asLiteralValue();
   }
 
   @override

--- a/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
@@ -91,8 +91,7 @@ class TypeDefBuilder extends TypeBuilder {
     ..definition = generator.primitive(p.dirname(filePath))
     ..docs.addAll(sanitizeDocs(docs)));
 
-  Class createTypeDefCodec() =>
-      Class((classBuilder) {
+  Class createTypeDefCodec() => Class((classBuilder) {
         final className = refer(name);
         final dirname = p.dirname(filePath);
 

--- a/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
@@ -41,7 +41,9 @@ class TypeDefBuilder extends TypeBuilder {
 
   @override
   TypeReference codec(BasePath from) {
-    return generator.codec(from);
+    return TypeReference((b) => b
+      ..symbol = '${name}Codec'
+      ..url = p.relative(filePath, from: from));
   }
 
   @override
@@ -80,6 +82,9 @@ class TypeDefBuilder extends TypeBuilder {
   GeneratedOutput build() {
     final typeDef = classbuilder.createTypeDef(
         name: name, reference: generator.primitive(p.dirname(filePath)));
-    return GeneratedOutput(classes: [], enums: [], typedefs: [typeDef]);
+    final typeDefCodec = classbuilder.createTypeDef(
+        name: '${name}Codec', reference: generator.codec(p.dirname(filePath)));
+    return GeneratedOutput(
+        classes: [], enums: [], typedefs: [typeDef, typeDefCodec]);
   }
 }

--- a/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
@@ -48,7 +48,7 @@ class TypeDefBuilder extends TypeBuilder {
 
   @override
   Expression codecInstance(BasePath from) {
-    return generator.codecInstance(from);
+    return codec(from).constInstance([]);
   }
 
   @override
@@ -80,11 +80,14 @@ class TypeDefBuilder extends TypeBuilder {
 
   @override
   GeneratedOutput build() {
-    final typeDef = classbuilder.createTypeDef(
-        name: name, reference: generator.primitive(p.dirname(filePath)));
-    final typeDefCodec = classbuilder.createTypeDef(
-        name: '${name}Codec', reference: generator.codec(p.dirname(filePath)));
+    final typeDef = createTypeDef();
+    final typeDefCodec = classbuilder.createTypeDefCodec(this);
     return GeneratedOutput(
-        classes: [], enums: [], typedefs: [typeDef, typeDefCodec]);
+        classes: [typeDefCodec], enums: [], typedefs: [typeDef]);
   }
+
+  TypeDef createTypeDef() => TypeDef((b) => b
+    ..name = name
+    ..definition = generator.primitive(p.dirname(filePath))
+    ..docs.addAll(sanitizeDocs(docs)));
 }

--- a/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
+++ b/packages/polkadart_cli/lib/src/typegen/types/typedef.dart
@@ -50,7 +50,7 @@ class TypeDefBuilder extends TypeBuilder {
   }
 
   @override
-  Expression valueFrom(BasePath from, Input input, {bool constant = false}) {
+  LiteralValue valueFrom(BasePath from, Input input, {bool constant = false}) {
     return generator.valueFrom(from, input, constant: constant);
   }
 

--- a/packages/polkadart_cli/test/typegen/composite_test.dart
+++ b/packages/polkadart_cli/test/typegen/composite_test.dart
@@ -68,8 +68,9 @@ void main() {
           generator.build().build(),
           [
             '// ignore_for_file: no_leading_underscores_for_library_prefixes\n',
-            'import \'package:polkadart/scale_codec.dart\' as _i1;\n',
             'import \'dart:typed_data\' as _i2;\n',
+            '\n',
+            'import \'package:polkadart/scale_codec.dart\' as _i1;\n',
             '\n',
             'class Point {\n',
             '  const Point({\n',
@@ -95,6 +96,18 @@ void main() {
             '        \'x\': x,\n',
             '        \'y\': y,\n',
             '      };\n',
+            '  @override\n',
+            '  bool operator ==(Object other) =>\n',
+            '      identical(\n',
+            '        this,\n',
+            '        other,\n',
+            '      ) ||\n',
+            '      other is Point && other.x == x && other.y == y;\n',
+            '  @override\n',
+            '  int get hashCode => Object.hash(\n',
+            '        x,\n',
+            '        y,\n',
+            '      );\n',
             '}\n',
             '\n',
             'class \$PointCodec with _i1.Codec<Point> {\n',
@@ -131,7 +144,7 @@ void main() {
             '    return size;\n',
             '  }\n',
             '}\n',
-            '',
+            ''
           ].join());
     });
   });

--- a/packages/polkadart_cli/test/typegen/typedef_test.dart
+++ b/packages/polkadart_cli/test/typegen/typedef_test.dart
@@ -15,7 +15,40 @@ void main() {
         generator: PrimitiveDescriptor.u8(1),
         docs: [],
       );
-      expect(generator.build().build(), 'typedef SomeType = int;\n');
+      expect(
+          generator.build().build(),
+          [
+            '// ignore_for_file: no_leading_underscores_for_library_prefixes\n',
+            'import \'package:polkadart/scale_codec.dart\' as _i1;\n',
+            '\n',
+            'typedef SomeType = int;\n',
+            '\n',
+            'class SomeTypeCodec with _i1.Codec<SomeType> {\n',
+            '  const SomeTypeCodec();\n',
+            '\n',
+            '  @override\n',
+            '  SomeType decode(_i1.Input input) {\n',
+            '    return _i1.U8Codec.codec.decode(input);\n',
+            '  }\n',
+            '\n',
+            '  @override\n',
+            '  void encodeTo(\n',
+            '    SomeType value,\n',
+            '    _i1.Output output,\n',
+            '  ) {\n',
+            '    _i1.U8Codec.codec.encodeTo(\n',
+            '      value,\n',
+            '      output,\n',
+            '    );\n',
+            '  }\n',
+            '\n',
+            '  @override\n',
+            '  int sizeHint(SomeType value) {\n',
+            '    return _i1.U8Codec.codec.sizeHint(value);\n',
+            '  }\n',
+            '}\n',
+            ''
+          ].join());
     });
     test('sequence typedef', () {
       final generator = TypeDefBuilder(
@@ -24,7 +57,40 @@ void main() {
         generator: SequenceDescriptor(2, PrimitiveDescriptor.u8(1)),
         docs: [],
       );
-      expect(generator.build().build(), 'typedef SomeType = List<int>;\n');
+      expect(
+          generator.build().build(),
+          [
+            '// ignore_for_file: no_leading_underscores_for_library_prefixes\n',
+            'import \'package:polkadart/scale_codec.dart\' as _i1;\n',
+            '\n',
+            'typedef SomeType = List<int>;\n',
+            '\n',
+            'class SomeTypeCodec with _i1.Codec<SomeType> {\n',
+            '  const SomeTypeCodec();\n',
+            '\n',
+            '  @override\n',
+            '  SomeType decode(_i1.Input input) {\n',
+            '    return _i1.U8SequenceCodec.codec.decode(input);\n',
+            '  }\n',
+            '\n',
+            '  @override\n',
+            '  void encodeTo(\n',
+            '    SomeType value,\n',
+            '    _i1.Output output,\n',
+            '  ) {\n',
+            '    _i1.U8SequenceCodec.codec.encodeTo(\n',
+            '      value,\n',
+            '      output,\n',
+            '    );\n',
+            '  }\n',
+            '\n',
+            '  @override\n',
+            '  int sizeHint(SomeType value) {\n',
+            '    return _i1.U8SequenceCodec.codec.sizeHint(value);\n',
+            '  }\n',
+            '}\n',
+            '',
+          ].join());
     });
     test('sequence typedef', () {
       final generator = TypeDefBuilder(
@@ -41,12 +107,39 @@ void main() {
       expect(
           generator.build().build(),
           [
-            '// ignore_for_file: no_leading_underscores_for_library_prefixes',
-            'import \'point.dart\' as _i1;',
+            '// ignore_for_file: no_leading_underscores_for_library_prefixes\n',
+            'import \'package:polkadart/scale_codec.dart\' as _i2;\n',
+            '\n',
+            'import \'point.dart\' as _i1;\n',
+            '\n',
+            'typedef SomeType = _i1.Point;\n',
+            '\n',
+            'class SomeTypeCodec with _i2.Codec<SomeType> {\n',
+            '  const SomeTypeCodec();\n',
+            '\n',
+            '  @override\n',
+            '  SomeType decode(_i2.Input input) {\n',
+            '    return _i1.Point.codec.decode(input);\n',
+            '  }\n',
+            '\n',
+            '  @override\n',
+            '  void encodeTo(\n',
+            '    SomeType value,\n',
+            '    _i2.Output output,\n',
+            '  ) {\n',
+            '    _i1.Point.codec.encodeTo(\n',
+            '      value,\n',
+            '      output,\n',
+            '    );\n',
+            '  }\n',
+            '\n',
+            '  @override\n',
+            '  int sizeHint(SomeType value) {\n',
+            '    return _i1.Point.codec.sizeHint(value);\n',
+            '  }\n',
+            '}\n',
             '',
-            'typedef SomeType = _i1.Point;',
-            '',
-          ].join('\n'));
+          ].join());
     });
   });
 }


### PR DESCRIPTION
This PR overrides the `operator ==` and `hashCode` method of generated files, this is a common practice in dart in order to be able to compare different objects but with same attributes.

example:
```dart
class A {
  final int value;
  
  @override
  bool operator ==(Object other) =>
      identical(this, other) || other is A && other.value == value;

  @override
  int get hashCode => Object.hash(value);
}

class B {
  final BigInt valueA;
  final A valueB;
  
  @override
  bool operator ==(Object other) =>
      identical(this, other) || other is B && other.valueA == valueA && other.valueB == valueB;

  @override
  int get hashCode => Object.hash(valueA, valueB);
}
```

