### PR TITLE
Fix build error

### DIFF
--- a/packages/polkadart_scale_codec/lib/primitives/i64.dart
+++ b/packages/polkadart_scale_codec/lib/primitives/i64.dart
@@ -7,8 +7,8 @@ class I64Codec with Codec<BigInt> {
 
   @override
   void encodeTo(BigInt value, Output output) {
-    if (value < BigInt.from(-9223372036854775808) ||
-        value > BigInt.from(9223372036854775807)) {
+    if (value < BigInt.parse('-9223372036854775808') ||
+        value > BigInt.parse('9223372036854775807')) {
       throw OutOfBoundsException();
     }
     U64Codec.codec.encodeTo(value.toUnsigned(64), output);


### PR DESCRIPTION
Use parsed bigInt from string and not from num in i64 primitive to fix build error for flutter web apps.
This fixes #319 and the build error when trying to build a flutter app with polkadart_scale_codec-1.1.0:
```
../../.pub-cache/hosted/pub.dev/polkadart_scale_codec-1.1.0/lib/primitives/i64.dart:11:29: Error: The integer literal 9223372036854775808 can't be represented in 64 bits.
Try using the BigInt class if you need an integer larger than 9,223,372,036,854,775,807 or less than -9,223,372,036,854,775,808.
        value > BigInt.from(9223372036854775808)) {
```

All tests pass.

